### PR TITLE
Update base image Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,10 @@
 FROM debian:sid
 MAINTAINER Zero Cho "http://itsze.ro"
 
-RUN apt-get update
-RUN apt-get install -y scala git curl openjdk-7-jdk
+RUN apt-get update && apt-get install -y \
+    scala \
+    git \
+    curl \
+    openjdk-7-jdk
 RUN git clone https://github.com/twitter/zipkin.git
 RUN (cd zipkin; bin/sbt compile)


### PR DESCRIPTION
Update base image Dockerfile according to Dockerfile best practice. [See RUN section](https://docs.docker.com/articles/dockerfile_best-practices/#the-dockerfile-instructions).

According to official doc, RUN apt-get update in one line will cause caching issues if the referenced archive gets updated.