### PR TITLE
Apply the "unofficial bash strict mode" to deploy/build.sh

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
 PREFIX="itszero/zipkin-"
 IMAGES=("base" "cassandra" "collector" "query" "web")
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 IMG_PREFIX="itszero/zipkin-"
 NAME_PREFIX="zipkin-"
 PUBLIC_PORT="8080"


### PR DESCRIPTION
This is generally good practice, and specifically stops the build process when one image fails to build. Especially useful when the build of the base image fails for some reason; without this change, it's ignored and the rest of the images are built from the last successfully built base image. This leads to much weeping and gnashing of teeth.