### PR TITLE
Fix docker run -p option format of deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -24,4 +24,4 @@ echo "** Starting zipkin-query"
 docker run -d --link="${NAME_PREFIX}cassandra:db" -p 9411:9411 --name="${NAME_PREFIX}query" "${IMG_PREFIX}query"
 
 echo "** Starting zipkin-web"
-docker run -d --link="${NAME_PREFIX}query:query" -p 8080:$PUBLIC_PORT -e "ROOTURL=${ROOT_URL}" --name="${NAME_PREFIX}web" "${IMG_PREFIX}web"
+docker run -d --link="${NAME_PREFIX}query:query" -p $PUBLIC_PORT:8080 -e "ROOTURL=${ROOT_URL}" --name="${NAME_PREFIX}web" "${IMG_PREFIX}web"


### PR DESCRIPTION
According to [docker-run](https://docs.docker.com/reference/run/#expose-incoming-ports) command reference, format of `-p` option is `hostPort:containerPort`.
But current `deploy.sh` assumes `containerPort:hostPort` and failed to change host port by `PUBLIC_PORT` value.
This PR fixes it.