### PR TITLE
[WIP] Cassandra config fix

### DIFF
--- a/cassandra/install.sh
+++ b/cassandra/install.sh
@@ -18,8 +18,8 @@ sed -i s/Xss180k/Xss256k/ /etc/cassandra/cassandra-env.sh
 sleep 10
 
 echo "*** Importing Scheme"
-wget https://raw.github.com/openzipkin/zipkin/master/zipkin-cassandra/src/schema/cassandra-schema.txt
-cassandra-cli -host localhost -port 9160 -f cassandra-schema.txt
+wget https://raw.githubusercontent.com/openzipkin/zipkin/master/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
+cqlsh --debug -f cassandra-schema-cql3.txt localhost
 
 echo "*** Stopping Cassandra"
 killall java

--- a/collector/collector-cassandra.scala
+++ b/collector/collector-cassandra.scala
@@ -13,23 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.SocketOptions
 import com.twitter.zipkin.builder.Scribe
 import com.twitter.zipkin.cassandra
 import com.twitter.zipkin.collector.builder.CollectorServiceBuilder
 import com.twitter.zipkin.storage.Store
-import com.twitter.logging.LoggerFactory
+import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
 import com.twitter.logging.LoggerFactory
 import com.twitter.logging.Level
 import com.twitter.logging.ConsoleHandler
 import com.twitter.zipkin.builder.ZipkinServerBuilder
 
-val keyspaceBuilder = cassandra.Keyspace.static(nodes = Set("localhost"))
-val cassandraBuilder = Store.Builder(
-  cassandra.StorageBuilder(keyspaceBuilder),
-  cassandra.IndexBuilder(keyspaceBuilder),
-  cassandra.AggregatesBuilder(keyspaceBuilder)
-)
 
+val cluster = Cluster.builder()
+  .addContactPoints("localhost")
+  .withSocketOptions(new SocketOptions().setConnectTimeoutMillis(10000).setReadTimeoutMillis(20000))
+  .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
+  .build()
+
+val storeBuilder = Store.Builder(new cassandra.SpanStoreBuilder(cluster))
 
 val loggerFactory = new LoggerFactory(
             node = "",
@@ -37,7 +41,6 @@ val loggerFactory = new LoggerFactory(
             handlers = List(ConsoleHandler())
             )
 
-
 CollectorServiceBuilder(Scribe.Interface(categories = Set("zipkin")))
-  .writeTo(cassandraBuilder)
-  .copy(serverBuilder = ZipkinServerBuilder(9410, 9900).loggers(List(loggerFactory))) 
+  .writeTo(storeBuilder)
+  .copy(serverBuilder = ZipkinServerBuilder(9410, 9900).loggers(List(loggerFactory)))

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ -z $DB_PORT_7000_TCP_ADDR ]]; then
+if [[ -z $DB_PORT_9042_TCP_ADDR ]]; then
   echo "** ERROR: You need to link the cassandra container as db."
   exit 1
 fi
@@ -9,5 +9,5 @@ CONFIG="${SERVICE_NAME}/config/collector-cassandra.scala"
 
 echo "** Starting ${SERVICE_NAME}..."
 cd zipkin
-sed -i "s/localhost/${DB_PORT_7000_TCP_ADDR}/" $CONFIG
+sed -i "s/localhost/${DB_PORT_9042_TCP_ADDR}/" $CONFIG
 ./$SERVICE_NAME/build/install/$SERVICE_NAME/bin/$SERVICE_NAME -f $CONFIG

--- a/query/run.sh
+++ b/query/run.sh
@@ -10,18 +10,20 @@ SERVICE_NAME="zipkin-query-service"
 CONFIG="${SERVICE_NAME}/config/query-cassandra.scala"
 
 cat << EOF > $CONFIG
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.SocketOptions
 import com.twitter.zipkin.builder.QueryServiceBuilder
 import com.twitter.zipkin.cassandra
 import com.twitter.zipkin.storage.Store
+import org.twitter.zipkin.storage.cassandra.ZipkinRetryPolicy
 
-// development mode.
-val keyspaceBuilder = cassandra.Keyspace.static(nodes = Set("${DB_PORT_7000_TCP_ADDR}"))
-val storeBuilder = Store.Builder(
-  cassandra.StorageBuilder(keyspaceBuilder),
-  cassandra.IndexBuilder(keyspaceBuilder),
-  cassandra.AggregatesBuilder(keyspaceBuilder))
+val cluster = Cluster.builder()
+  .addContactPoints("${DB_PORT_9042_TCP_ADDR}")
+  .withSocketOptions(new SocketOptions().setConnectTimeoutMillis(10000).setReadTimeoutMillis(20000))
+  .withRetryPolicy(ZipkinRetryPolicy.INSTANCE)
+  .build()
 
-QueryServiceBuilder(storeBuilder)
+val storeBuilder = Store.Builder(new cassandra.SpanStoreBuilder(cluster))
 EOF
 
 echo "** Starting ${SERVICE_NAME}..."


### PR DESCRIPTION
**Work In Progress**

I noticed our docker containers are not working anymore since the Cassandra driver update has been merged.

I tried to fix things (see commits for details) but still have following issues:

- [ ] `zipkin-collector` can't connect to cassandra: `com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /172.17.0.61:9042 ...`
- [ ] `zipkin-query` throws a `ClassCastException` probably because of config change:
`Exception in thread "main" java.lang.ClassCastException: scala.runtime.BoxedUnit cannot be cast to com.twitter.zipkin.builder.Builder
	at com.twitter.zipkin.query.Main$.main(Main.scala:39)`

These issues happen both when using `deploy.sh` script and when using `docker-compose`.
