### PR TITLE
Minimal images

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM jeanblanchard/java:serverjre-8
+FROM delitescere/java:8
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 RUN apk update && apk add netcat-openbsd curl

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,10 +1,7 @@
-FROM debian:sid
+FROM jeanblanchard/java:serverjre-8
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-RUN apt-get update && apt-get install -y \
-  curl \
-  openjdk-8-jre-headless \
-  netcat
+RUN apk update && apk add netcat-openbsd curl
 
 ENV ZIPKIN_REPO https://jcenter.bintray.com
 ENV ZIPKIN_VERSION 1.5.1

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -1,6 +1,8 @@
 FROM quay.io/openzipkin/zipkin-base:base-1.5.1
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
+ENV CASSANDRA_VERSION 2.1.9
+
 ADD install.sh /usr/local/bin/install
 RUN /usr/local/bin/install
 ADD run.sh /usr/local/bin/run

--- a/cassandra/install.sh
+++ b/cassandra/install.sh
@@ -1,29 +1,16 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 
-echo "*** Adding Cassandra deb source"
-cat << EOF >> /etc/apt/sources.list
-deb http://www.apache.org/dist/cassandra/debian 21x main
-deb-src http://www.apache.org/dist/cassandra/debian 21x main
-EOF
-
-echo "*** Importing Cassandra deb keys"
-gpg --keyserver keys.gnupg.net --recv-keys 749D6EEC0353B12C
-gpg --export --armor 749D6EEC0353B12C | apt-key add -
+echo "*** Installing Python"
+apk add python
 
 echo "*** Installing Cassandra"
-apt-get update
-# adduser, python and python-support are dependencies of cassandra
-# we'll install cassandra without dependency checks to use the JRE 8 provided by the base image
-# otherwise it'd pull in JRE 7
-apt-get install -y procps wget adduser python>=2.7 python-support>=0.90.0
-apt-get download cassandra
-dpkg --force-depends -i cassandra*.deb
-rm cassandra*.deb
+curl -L http://downloads.datastax.com/community/dsc-cassandra-$CASSANDRA_VERSION-bin.tar.gz | tar xz
+mv dsc-cassandra-$CASSANDRA_VERSION /cassandra
 
 echo "*** Starting Cassandra"
-sed -i s/Xss180k/Xss256k/ /etc/cassandra/cassandra-env.sh
+sed -i s/Xss180k/Xss256k/ /cassandra/conf/cassandra-env.sh
 /usr/sbin/cassandra
 
 timeout=300
@@ -34,12 +21,12 @@ while [[ "$timeout" -gt 0 ]] && ! cqlsh -e 'SHOW VERSION' localhost >/dev/null 2
 done
 
 echo "*** Importing Scheme"
-wget https://raw.githubusercontent.com/openzipkin/zipkin/$ZIPKIN_VERSION/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt
-cqlsh --debug -f cassandra-schema-cql3.txt localhost
+curl https://raw.githubusercontent.com/openzipkin/zipkin/$ZIPKIN_VERSION/zipkin-cassandra-core/src/main/resources/cassandra-schema-cql3.txt \
+     | /cassandra/bin/cqlsh --debug localhost
 
 echo "*** Stopping Cassandra"
 pkill -f java
 
-mv /etc/cassandra/cassandra.yaml /etc/cassandra/cassandra.default.yaml
+mv /cassandra/conf/cassandra.yaml /cassandra/conf/cassandra.default.yaml
 
 echo "*** Image build complete"

--- a/cassandra/install.sh
+++ b/cassandra/install.sh
@@ -11,7 +11,7 @@ mv dsc-cassandra-$CASSANDRA_VERSION /cassandra
 
 echo "*** Starting Cassandra"
 sed -i s/Xss180k/Xss256k/ /cassandra/conf/cassandra-env.sh
-/usr/sbin/cassandra
+/cassandra/bin/cassandra
 
 timeout=300
 while [[ "$timeout" -gt 0 ]] && ! cqlsh -e 'SHOW VERSION' localhost >/dev/null 2>/dev/null; do

--- a/cassandra/run.sh
+++ b/cassandra/run.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
-IP=`hostname --ip-address`
-CONFIG_TMPL="/etc/cassandra/cassandra.default.yaml"
-CONFIG="/etc/cassandra/cassandra.yaml"
-rm $CONFIG; cp $CONFIG_TMPL $CONFIG
+
+set -eu
+
+IP=`hostname -i`
+CONFIG_TMPL="/cassandra/conf/cassandra.default.yaml"
+CONFIG="/cassandra/conf/cassandra.yaml"
+rm -f $CONFIG; cp $CONFIG_TMPL $CONFIG
 sed -i -e "s/^listen_address.*/listen_address: $IP/" $CONFIG
 sed -i -e "s/^rpc_address.*/rpc_address: 0.0.0.0/" $CONFIG
 sed -i -e "s/^\# broadcast_rpc_address.*/broadcast_rpc_address: $IP/" $CONFIG
-/usr/sbin/cassandra -f
+/cassandra/bin/cassandra -f

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-collector-service/$ZIPKIN_VERSION/zipkin-collector-service-$ZIPKIN_VERSION-all.jar > zipkin-collector.jar
 
 ADD run.sh /usr/local/bin/run.sh
-ENTRYPOINT ["/usr/local/bin/run.sh"]
+CMD /usr/local/bin/run.sh
 
 EXPOSE 9410

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
   if [[ -z $DB_PORT_9042_TCP_ADDR ]]; then	
   	echo "** ERROR: You need to link container with Cassandra container or specify CASSANDRA_CONTACT_POINTS env var."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 cassandra:
-  image: quay.io/openzipkin/zipkin-cassandra:1.4.1
+  image: quay.io/openzipkin/zipkin-cassandra:1.5.1
   ports:
     - 9042:9042
 collector:
-  image: quay.io/openzipkin/zipkin-collector:1.4.1
+  image: quay.io/openzipkin/zipkin-collector:1.5.1
   environment:
     - BLOCK_ON_CASSANDRA=true
   expose:
@@ -14,7 +14,7 @@ collector:
   links:
     - cassandra:db
 query:
-  image: quay.io/openzipkin/zipkin-query:1.4.1
+  image: quay.io/openzipkin/zipkin-query:1.5.1
   environment:
     - BLOCK_ON_CASSANDRA=true
   expose:
@@ -25,7 +25,7 @@ query:
   links:
     - cassandra:db
 web:
-  image: quay.io/openzipkin/zipkin-web:1.4.1
+  image: quay.io/openzipkin/zipkin-web:1.5.1
   links:
     - query
   ports:

--- a/query/Dockerfile
+++ b/query/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-query-service/$ZIPKIN_VERSION/zipkin-query-service-$ZIPKIN_VERSION-all.jar > zipkin-query.jar
 
 ADD run.sh /usr/local/bin/run.sh
-ENTRYPOINT ["/usr/local/bin/run.sh"]
+CMD /usr/local/bin/run.sh
 
 EXPOSE 9411

--- a/query/run.sh
+++ b/query/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
   if [[ -z $DB_PORT_9042_TCP_ADDR ]]; then  
     echo "** ERROR: You need to link container with Cassandra container or specify CASSANDRA_CONTACT_POINTS env var."

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-web/$ZIPKIN_VERSION/zipkin-web-$ZIPKIN_VERSION-all.jar > zipkin-web.jar
 
 ADD run.sh /usr/local/bin/run
-ENTRYPOINT ["/usr/local/bin/run"]
+CMD /usr/local/bin/run
 
 EXPOSE 8080

--- a/web/run.sh
+++ b/web/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [[ -z $QUERY_PORT_9411_TCP_ADDR ]]; then
   echo "** ERROR: You need to link the query service as query."
   exit 1


### PR DESCRIPTION
**Don't merge!** Being re-done to use another base image and no oracle java.

## What, how

This change reduces the size of `zipkin-base` from 466.2 MB to 181.8 MB. This is achieved by switching from `debian:sid` to a minimal base image built on Alpine Linux; a Java Docker image doesn't get much smaller than this. Here's what changes.

 * Package management, obviously. Specifically, there's no Cassandra package for Alpine Linux, so we just install the dependencies manually, and download the binary tarball.
 * `/bin/bash` is `/bin/sh`
 * We go from OpenJDK 8 headless to Oracle server JRE 8. This may be a concern from a licensing point of view, **looking for input** on this. I still went with this image because I couldn't find a minimal, OpenJDK based image I could trust.

## Testing

Pulled up `docker-compose up` with these images built locally, ran `zipkin-tracegen` against them, and saw traces on the web interface.