### PR TITLE
Automated release process using Quay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # docker-zipkin
 
-Dockerfiles for starting a Zipkin instance backed by Cassandra. Automatically built images are available on Docker Hub
-under the [OpenZipkin](https://hub.docker.com/u/openzipkin/) organization.
+Dockerfiles for starting a Zipkin instance backed by Cassandra. Automatically built images are available on Quay.io
+under the [OpenZipkin](https://quay.io/organization/openzipkin) organization, and are mirrored to
+[Docker Hub](https://hub.docker.com/u/openzipkin/).
 
 ## Running
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,51 +1,43 @@
 # Releasing a New Version
 
-This document describes how to release a new set of Docker images for OpenZipkin.
+This document describes how to release a new set of Docker images for OpenZipkin. The images are built automatically
+on [quay.io](https://quay.io) and mirrored to Docker Hub.
 
-1. **Update the Build Settings of the automated builds**
+## Tag structure
 
-   Update the (git tag) - (docker tag) mapping on the Build Settings page of each affected project on Docker Hub.
-   These are, unless something special happens: [`zipkin-base`](https://hub.docker.com/r/openzipkin/zipkin-base/~/settings/automated-builds/),
-   [`zipkin-cassandra`](https://hub.docker.com/r/openzipkin/zipkin-cassandra/~/settings/automated-builds/),
-   [`zipkin-collector`](https://hub.docker.com/r/openzipkin/zipkin-collector/~/settings/automated-builds/),
-   [`zipkin-query`](https://hub.docker.com/r/openzipkin/zipkin-query/~/settings/automated-builds/), and
-   [`zipkin-web`](https://hub.docker.com/r/openzipkin/zipkin-web/~/settings/automated-builds/).
+Each release is tagged with a semantic version number like `1.4.1`. The Docker tags `1.4` and `1` point to the latest
+tag under them, to let users choose the level of version pinning they prefer.
 
-    The tag mappings should look as follows:
+## Release process
 
-  * Subminor releases (`1.2.2` -> `1.2.3`)
-    * Create a new docker tag `1.2.3` pointing to the git tag you'll create (probably `1.2.3-rc1` on the first try)
-    * Change the docker tag `1.2` to point to the git same git tag
-  * Minor releases (`1.2.2` -> `1.3.1`)
-    * Create a new docker tag `1.3` pointing to the git tag you'll create (probably `1.3.1-rc1` on the first try)
-    * Create a new docker tag `1.3.1` pointing to the same git tag
+1. **Get a Quay.io OAuth 2 token**
 
-1. **Bump the `ZIPKIN_VERSION` ENV var in `zipkin-base`**
+   Go to https://quay.io/organization/openzipkin/application/QREQHLDQGW2LI4OGGD6C?tab=gen-token and generate a token
+   with "Read/Write to any accessible repositories" permissions. Export this token to be used by the release script:
+   `export QUAYIO_OAUTH2_TOKEN='...'`
 
-   This will be used in various install scripts to pull in the right Zipkin release.
+   This token will be used to sync up the Docker tags `1` and `1.4` when you release `1.4.1`.
 
-1. **Bump the version in `FROM` statement in `Dockerfile`s**
+1. **Activate your Docker environment**
 
-   For the projects that depend on `zipkin-base`, change their `Dockerfile`s to start building `FROM` the tag
-   that will be created by this release. These are, unless something special happens: `cassandra`, `collector`, `query`, and `web`.
-   At this point in time the images are not buildable, but that's fine. Sequencing the release steps this way
-   saves some manual work, reducing the chance of mistakes (thus further saving manual work).
+   Make sure you have `$DOCKER_HOST` and friends set. The easiest way to check this is to run `docker version`, which
+   will print the version of your Docker daemon as well as your server. For many people, `eval $(docker-machine env dev)`
+   or some slight variation will take care of this.
 
-1. **Create, push the git tag**
+1. **Log in to Docker Hub**
 
-   Make extra sure it's the same git tag you configured for the automated builds. Before pushing may be a good time
-   to verify that the affected automated builds all have the same Build Settings.
+   Make sure your Docker client configuration has your credentials to hub.docker.com. The easiest way to get this right
+   is to issue the command `docker login` and enter your credentials.
 
-   This starts the build of `zipkin-base`, which you can track under [openzipkin/zipkin-base](https://hub.docker.com/r/openzipkin/zipkin-base/builds/)
+   This will be used when syncing the built images from Quay.io to Docker Hub.
 
-1. **Wait for `zipkin-base`**
+1. **Run `release.sh $VERSION`**
 
-   Once that's finished, it automatically triggers the build of `zikpin-cassandra`, `zipkin-collector`, `zipkin-query`, and `zipkin-web`.
-   They'll use the newly built base image, since you've already changed their `FROM` statements to make it so.
+   Version should be a semantic version number, like `1.4.1`. Go grab a coffee.
 
-1. **Wait for the rest of the images**
-
-   As usual, you want to wait for: `zipkin-cassandra`, `zipkin-collector`, `zipkin-query`, and `zipkin-web`.
+   The script will create a Git tag `base-1.4.1` that triggers the build of `zipkin-base`, wait for that build, then
+   create another Git tag `1.4.1` that triggers the rest of the builds. It waits for those, then syncs up the Docker
+   tags `1` and `1.4` to the Docker tag `1.4.1` created by these builds. Finally it syncs the built images to Docker Hub.
 
 1. **Test the new images**
 
@@ -58,3 +50,4 @@ This document describes how to release a new set of Docker images for OpenZipkin
 
    Congratulations, the intersection of the sets (OpenZipkin users) and (Docker users) can now enjoy the latest
    and greatest Zipkin release!
+

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzipkin/zipkin-base:1.4
+FROM quay.io/openzipkin/zipkin-base:base-0.0.0
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 ADD install.sh /usr/local/bin/install

--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzipkin/zipkin-base:1.4
+FROM quay.io/openzipkin/zipkin-base:base-0.0.0
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-collector-service/$ZIPKIN_VERSION/zipkin-collector-service-$ZIPKIN_VERSION-all.jar > zipkin-collector.jar

--- a/query/Dockerfile
+++ b/query/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzipkin/zipkin-base:1.4
+FROM quay.io/openzipkin/zipkin-base:base-0.0.0
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-query-service/$ZIPKIN_VERSION/zipkin-query-service-$ZIPKIN_VERSION-all.jar > zipkin-query.jar

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+# Constants
+api="https://quay.io/api/v1"
+started_at=$(date +%s)
+
+## Read input and env
+version="$1"
+# Base images
+base_images="${BASE_IMAGES:-zipkin-base}"
+base_dirs="${BASE_DIRS:-base}"
+# Service images
+service_images="${SERVICE_IMAGES:-zipkin-cassandra zipkin-collector zipkin-query zipkin-web}"
+service_dirs="${SERVICE_DIRS:-cassandra collector query web}"
+# Remotes, auth
+docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
+quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"
+git_remote="${GIT_REMOTE:-origin}"
+
+prefix() {
+    while read line; do
+        echo "[$(date +"%x %T")][${1}] $line"
+    done
+}
+
+bump-zipkin-version () {
+    local version="$1"; shift
+    local images="$@"
+    for image in $images; do
+        echo "Bumping ZIPKIN_VERSION in the Dockerfile of $image..."
+        dockerfile="${image}/Dockerfile"
+        sed -i.bak -e "s/ENV ZIPKIN_VERSION .*/ENV ZIPKIN_VERSION ${version}/" "$dockerfile"
+        rm "${dockerfile}.bak"
+        git add "$dockerfile"
+    done
+
+    git commit -m "Bump ZIPKIN_VERSION to $version"
+    git push
+}
+
+create-and-push-tag () {
+    local tag="$1"
+    echo "Creating and pushing tag $tag..."
+    git tag "$tag" --force
+    git push "$git_remote" "$tag" --force
+}
+
+fetch-last-build () {
+    local tag="$1"
+    local image="$2"
+    local repo="${docker_organization}/${image}"
+
+    curl -s "${api}/repository/${repo}/build/" | jq ".builds | map(select(.tags | contains([\"${tag}\"])))[0]"
+}
+
+build-started-after-me () {
+    local build="$1"
+
+    build_started_at_str="$(echo "$build" | jq '.started' -r)"
+    build_started_at="$(date --date "$build_started_at_str" +%s)"
+    [[ "$started_at" -lt "$build_started_at" ]] || return 1
+}
+
+wait-for-build-to-start () {
+    local tag="$1"
+    local image="$2"
+    local repo="${docker_organization}/${image}"
+
+    timeout=300
+    while [[ "$timeout" -gt 0 ]]; do
+        echo >&2 "Waiting for the build of $image for version $tag to start for $timeout more seconds..."
+        build="$(fetch-last-build "$tag" "$image")"
+        if [[ "$build" != "null" ]] && build-started-after-me "$build"; then
+            build_id=$(echo "$build" | jq '.id' -r)
+            echo >&2 "Build started: https://quay.io/repository/$repo/build/$build_id"
+            echo "$build_id"
+            return
+        fi
+        timeout=$(($timeout - 10))
+        sleep 10
+    done
+
+    echo "Build didn't start in a minute (or I failed to recognized it). Bailing out."
+    return 1
+}
+
+wait-for-build-to-finish () {
+    local image="$1"
+    local build_id="$2"
+
+    echo "Waiting for build of $image with tag $tag to finish..."
+    while true; do
+        phase="$(curl -s "${api}/repository/${docker_organization}/${image}/build/${build_id}" | jq '.phase' -r)"
+        if [[ "$phase" == 'complete' ]]; then
+            echo "Build completed."
+            return
+        elif [[ "$phase" == 'error' ]]; then
+            echo "Build failed. Bailing out."
+            exit 1
+        else
+            echo "Build of $image is in phase \"${phase}\", waiting..."
+            sleep 10
+        fi
+    done
+}
+
+wait-for-builds () {
+    local tag="$1"; shift
+    local images="$@"
+    for image in $images; do
+        echo "Waiting for build of $image with tag $tag"
+        build_id="$(wait-for-build-to-start "$tag" "$image")"
+        wait-for-build-to-finish "$image" "$build_id"
+    done
+}
+
+sync-quay-tag () {
+    local repo="${docker_organization}/$1"
+    local reference_tag="$2"
+    local tag_to_move="$3"
+
+    echo "Syncing tag ${tag_to_move} to ${reference_tag} on ${repo}"
+    image_id="$(curl -s "${api}/repository/${repo}/tag/${reference_tag}/images" | jq '.images | sort_by(-.sort_index)[0].id' -r)"
+    echo "Image id is ${image_id}"
+    curl -s "${api}/repository/${repo}/tag/${tag_to_move}" \
+         -H "Authorization: Bearer $quayio_oauth2_token" \
+         -H "Content-Type: application/json" \
+         -XPUT -d "{\"image\": \"$image_id\"}"
+    echo
+}
+
+sync-quay-tags () {
+    local subminor_tag="$1"; shift
+    local minor_tag="$1"; shift
+    local major_tag="$1"; shift
+    local images="$@"
+
+    for image in $images; do
+        sync-quay-tag "$image" "$subminor_tag" "$minor_tag"
+        sync-quay-tag "$image" "$subminor_tag" "$major_tag"
+    done
+}
+
+bump-dockerfiles () {
+    local tag="$1"; shift
+    local images="$@"
+    for image in $images; do
+        echo "Bumping base image of $image to $tag"
+        dockerfile="${image}/Dockerfile"
+        FROM_line_without_tag="$(grep -E '^FROM ' "$dockerfile" | cut -f1 -d:)"
+        sed -i.bak -e "s~^FROM .*~${FROM_line_without_tag}:${tag}~" "$dockerfile"
+        rm "${dockerfile}.bak"
+        git add "$dockerfile"
+    done
+    git commit -m "Bump base image version of services to ${tag}"
+    git push
+}
+
+sync-to-dockerhub () {
+    local tag="$1"; shift
+    local images="$@"
+    for image in $images; do
+        dockerhub_name="${docker_organization}/${image}:${tag}"
+        quay_name="quay.io/${dockerhub_name}"
+        echo "Syncing ${quay_name} to Docker Hub as ${dockerhub_name}"
+        docker pull "$quay_name"
+        docker tag -f "$quay_name" "$dockerhub_name"
+        docker push "$dockerhub_name"
+    done
+}
+
+main () {
+    # Check that the version is something we like
+    if ! echo "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' -q; then
+        echo "Usage: $0 <version>"
+        echo "Where version must be <major>.<minor>.<subminor>"
+        exit 1
+    fi
+
+    # The git tags we'll create
+    major_tag=$(echo "$version" | cut -f1 -d. -s)
+    minor_tag=$(echo "$version" | cut -f1-2 -d. -s)
+    subminor_tag="$version"
+    base_tag="base-$version"
+
+    action_plan="
+    bump-zipkin-version     $version $base_dirs                                 2>&1 | prefix bump-zipkin-version
+    create-and-push-tag     $base_tag                                           2>&1 | prefix tag-base-image
+    wait-for-builds         $base_tag $base_images                              2>&1 | prefix wait-for-base-build
+    bump-dockerfiles        $base_tag $service_dirs                             2>&1 | prefix bump-dockerfiles
+    create-and-push-tag     $subminor_tag                                       2>&1 | prefix tag-service-images
+    wait-for-builds         $subminor_tag $service_images                       2>&1 | prefix wait-for-service-builds
+    sync-quay-tags          $subminor_tag $minor_tag $major_tag $service_images 2>&1 | prefix sync-quay-tags
+    sync-to-dockerhub       $base_tag $base_images                              2>&1 | prefix sync-base-image-to-dockerhub
+    sync-to-dockerhub       $subminor_tag $service_images                       2>&1 | prefix sync-${subminor_tag}-to-dockerhub
+    sync-to-dockerhub       $minor_tag $service_images                          2>&1 | prefix sync-${minor_tag}-to-dockerhub
+    sync-to-dockerhub       $major_tag $service_images                          2>&1 | prefix sync-${major_tag}-to-dockerhub
+    "
+
+    echo "Starting release $version. Action plan:"
+    echo "$action_plan" | sed -e 's/ *2>&1 \| prefix.*//'
+
+    eval "$action_plan"
+
+    echo
+    echo "All done. Now it's time to update docker-compose.yml with the new versions and validate that the new images work."
+    echo "Once you're done with that:"
+    echo
+    echo "    git commit docker-compose.yml -m 'Release $version'; git push"
+}
+
+main
+

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM openzipkin/zipkin-base:1.4
+FROM quay.io/openzipkin/zipkin-base:base-0.0.0
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 RUN curl -SL $ZIPKIN_REPO/io/zipkin/zipkin-web/$ZIPKIN_VERSION/zipkin-web-$ZIPKIN_VERSION-all.jar > zipkin-web.jar


### PR DESCRIPTION
This is a better implementation of https://github.com/openzipkin/docker-zipkin/pull/38, see the description of that PR for a detailed discussion of the trade-offs behind this.

When this is merged, the release script will still be failing at the "sync to Docker Hub" step, since at this moment the repos on Docker Hub are automated builds, which don't accept direct pushes. We'll need to migrate those to normal repositories.

After that, the next step is running this process on Travis, triggered by a tag (say `release-1.4.0`, to not confuse the build triggers in Quay.io)