### PR TITLE
Adds MySQL image for testing

### DIFF
--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,0 +1,42 @@
+mysql:
+  image: openzipkin/zipkin-mysql:1.17.1
+  expose:
+    - 3306
+  ports:
+    - 3306:3306
+collector:
+  image: openzipkin/zipkin-collector:1.17.1
+  environment:
+    - MYSQL_USER=zipkin
+    - MYSQL_PASS=zipkin
+  entrypoint: /bin/sh
+  command: -c "MYSQL_HOST=${MYSQL_PORT_3306_TCP_ADDR} java -jar /zipkin/zipkin-collector.jar -f /collector-mysql.scala"
+  expose:
+    - 9410
+  ports:
+    - 9410:9410
+  links:
+    - mysql
+query:
+  image: openzipkin/zipkin-query:1.17.1
+  environment:
+    - MYSQL_USER=zipkin
+    - MYSQL_PASS=zipkin
+  entrypoint: /bin/sh
+  command: -c "MYSQL_HOST=${MYSQL_PORT_3306_TCP_ADDR} SCRIBE_HOST=${COLLECTOR_PORT_9410_TCP_ADDR} SCRIBE_PORT=9410 java -jar /zipkin/zipkin-query.jar -f /query-mysql.scala"
+  expose:
+    - 9411
+  ports:
+    - 9411:9411
+  links:
+    - mysql
+    - collector
+web:
+  image: openzipkin/zipkin-web:1.17.1
+  ports:
+    - 8080:8080
+    - 9990:9990
+  links:
+    - collector
+    - query
+

--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/openzipkin/zipkin-base:base-1.17.1
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+WORKDIR /mysql
+ADD install.sh /mysql/install
+RUN /mysql/install
+
+ADD run.sh /mysql/run.sh
+CMD /mysql/run.sh
+
+EXPOSE 3306

--- a/mysql/install.sh
+++ b/mysql/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eux
+
+echo "*** Installing MySQL"
+apk add --update mysql mysql-client
+mysql_install_db --user=mysql --basedir=/usr/ --datadir=/mysql/data --force
+chown -R mysql /mysql
+# change default run path to the work dir
+sed -i -e"s~/run/mysqld~/mysql~g" -e 's/#.*$//' -e '/^$/d' /etc/mysql/my.cnf
+
+echo "*** Starting MySQL"
+mysqld --user=mysql --basedir=/usr/ --datadir=/mysql/data &
+
+timeout=300
+while [[ "$timeout" -gt 0 ]] && ! mysql --user=mysql --protocol=socket -uroot -e 'SELECT 1' >/dev/null 2>/dev/null; do
+    echo "Waiting ${timeout} seconds for mysql to come up"
+    sleep 2
+    timeout=$(($timeout - 2))
+done
+
+echo "*** Importing Schema"
+curl https://raw.githubusercontent.com/openzipkin/zipkin/$ZIPKIN_VERSION/zipkin-anormdb/src/main/resources/mysql.sql > /mysql/zipkin.sql
+mysql --verbose --user=mysql --protocol=socket -uroot <<-EOSQL
+USE mysql ;
+
+DELETE FROM mysql.user ;
+DROP DATABASE IF EXISTS test ;
+
+SET GLOBAL innodb_file_format=Barracuda ;
+CREATE DATABASE zipkin ;
+
+USE zipkin;
+SOURCE /mysql/zipkin.sql ;
+
+GRANT SELECT, INSERT, DELETE ON zipkin.* TO zipkin@'%' IDENTIFIED BY 'zipkin' WITH GRANT OPTION ;
+FLUSH PRIVILEGES ;
+EOSQL
+
+echo "*** Stopping MySQL"
+pkill -f mysqld
+
+echo "*** Cleaning Up"
+apk del mysql-client --purge
+
+echo "*** Image build complete"

--- a/mysql/run.sh
+++ b/mysql/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/mysqld_safe --user=mysql --basedir=/usr/ --datadir=/mysql/data

--- a/release.sh
+++ b/release.sh
@@ -35,8 +35,8 @@ release_tag="$1"
 base_images="${BASE_IMAGES:-zipkin-base}"
 base_dirs="${BASE_DIRS:-base}"
 # Service images
-service_images="${SERVICE_IMAGES:-zipkin-cassandra zipkin-collector zipkin-query zipkin-web}"
-service_dirs="${SERVICE_DIRS:-cassandra collector query web}"
+service_images="${SERVICE_IMAGES:-zipkin-cassandra zipkin-mysql zipkin-collector zipkin-query zipkin-web}"
+service_dirs="${SERVICE_DIRS:-cassandra mysql collector query web}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"


### PR DESCRIPTION
This adds a MySQL image so that we can test our corresponding spanstore.
This adds on our base image to keep size down, and also help capture
the minimum configuration needed when creating the zipkin MySQL schema.

By having a small image, our travis builds take longer, those looking
for a 5 minute quick start are more likely to be able to achieve that,
and those troubleshooting docker problems will spend less time pulling
images.