### PR TITLE
Uses STORAGE_TYPE variable to decouple span storage implementations

### DIFF
--- a/base/.cassandra_profile
+++ b/base/.cassandra_profile
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
+  if [[ -z $STORAGE_PORT_9042_TCP_ADDR ]]; then	
+    echo "** ERROR: You need to link with a Cassandra container as 'storage' or specify CASSANDRA_CONTACT_POINTS env var."
+    echo "STORAGE_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points."
+  fi
+  CASSANDRA_CONTACT_POINTS=$STORAGE_PORT_9042_TCP_ADDR
+fi
+
+export CASSANDRA_CONTACT_POINTS
+echo "Cassandra contact points: $CASSANDRA_CONTACT_POINTS"

--- a/base/.mysql_profile
+++ b/base/.mysql_profile
@@ -1,0 +1,15 @@
+#!/bin/sh
+if [[ -z $MYSQL_HOST ]]; then
+  if [[ -z $STORAGE_PORT_3306_TCP_ADDR ]]; then  
+    echo "** ERROR: You need to link with a MySQL container as 'storage' or specify MYSQL_HOST env var."
+    echo "STORAGE_PORT_3306_TCP_ADDR (container link) or MYSQL_HOST should contain a MySQL hostname."
+    exit 1
+  fi
+  MYSQL_HOST=$STORAGE_PORT_3306_TCP_ADDR
+fi
+
+export MYSQL_HOST
+export MYSQL_USER=${MYSQL_USER:=zipkin}
+export MYSQL_PASS=${MYSQL_PASS:=zipkin}
+
+echo "MySQL host: $MYSQL_HOST"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,4 +7,7 @@ ENV ZIPKIN_REPO https://jcenter.bintray.com
 ENV ZIPKIN_VERSION 1.17.1
 
 RUN mkdir /zipkin
+ADD .cassandra_profile /zipkin/.cassandra_profile
+ADD .mysql_profile /zipkin/.mysql_profile
+
 WORKDIR /zipkin

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
-if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
-  if [[ -z $DB_PORT_9042_TCP_ADDR ]]; then	
-  	echo "** ERROR: You need to link container with Cassandra container or specify CASSANDRA_CONTACT_POINTS env var."
-  	echo "DB_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points"
-  	exit 1
-  fi
-  CASSANDRA_CONTACT_POINTS=$DB_PORT_9042_TCP_ADDR
-fi
-
-export CASSANDRA_CONTACT_POINTS
-echo "Cassandra contact points: $CASSANDRA_CONTACT_POINTS"
+source .${STORAGE_TYPE}_profile
 
 echo "** Starting zipkin collector..."
-java -jar zipkin-collector.jar -f /collector-cassandra.scala
+java -jar zipkin-collector.jar -f /collector-${STORAGE_TYPE}.scala

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,35 +1,29 @@
 mysql:
   image: openzipkin/zipkin-mysql:1.17.1
-  expose:
-    - 3306
   ports:
     - 3306:3306
 collector:
   image: openzipkin/zipkin-collector:1.17.1
   environment:
-    - MYSQL_USER=zipkin
-    - MYSQL_PASS=zipkin
-  entrypoint: /bin/sh
-  command: -c "MYSQL_HOST=${MYSQL_PORT_3306_TCP_ADDR} java -jar /zipkin/zipkin-collector.jar -f /collector-mysql.scala"
+    - STORAGE_TYPE=mysql
   expose:
     - 9410
   ports:
     - 9410:9410
+    - 9900:9900
   links:
-    - mysql
+    - mysql:storage
 query:
   image: openzipkin/zipkin-query:1.17.1
   environment:
-    - MYSQL_USER=zipkin
-    - MYSQL_PASS=zipkin
-  entrypoint: /bin/sh
-  command: -c "MYSQL_HOST=${MYSQL_PORT_3306_TCP_ADDR} SCRIBE_HOST=${COLLECTOR_PORT_9410_TCP_ADDR} SCRIBE_PORT=9410 java -jar /zipkin/zipkin-query.jar -f /query-mysql.scala"
+    - STORAGE_TYPE=mysql
   expose:
     - 9411
   ports:
     - 9411:9411
+    - 9901:9901
   links:
-    - mysql
+    - mysql:storage
     - collector
 web:
   image: openzipkin/zipkin-web:1.17.1
@@ -39,4 +33,3 @@ web:
   links:
     - collector
     - query
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,32 @@
 cassandra:
-  image: openzipkin/zipkin-cassandra:1.17.0
+  image: openzipkin/zipkin-cassandra:1.17.1
   ports:
     - 9042:9042
 collector:
-  image: openzipkin/zipkin-collector:1.17.0
+  image: openzipkin/zipkin-collector:1.17.1
+  environment:
+    - STORAGE_TYPE=cassandra
   expose:
     - 9410
   ports:
     - 9410:9410
     - 9900:9900
   links:
-    - cassandra:db
+    - cassandra:storage
 query:
-  image: openzipkin/zipkin-query:1.17.0
+  image: openzipkin/zipkin-query:1.17.1
+  environment:
+    - STORAGE_TYPE=cassandra
   expose:
     - 9411
   ports:
     - 9411:9411
     - 9901:9901
   links:
-    - cassandra:db
+    - cassandra:storage
     - collector
 web:
-  image: openzipkin/zipkin-web:1.17.0
+  image: openzipkin/zipkin-web:1.17.1
   ports:
     - 8080:8080
     - 9990:9990

--- a/query/run.sh
+++ b/query/run.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
-if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
-  if [[ -z $DB_PORT_9042_TCP_ADDR ]]; then  
-    echo "** ERROR: You need to link container with Cassandra container or specify CASSANDRA_CONTACT_POINTS env var."
-    echo "DB_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points"
-    exit 1
-  fi
-  CASSANDRA_CONTACT_POINTS=$DB_PORT_9042_TCP_ADDR
-fi
-
-export CASSANDRA_CONTACT_POINTS
-echo "Cassandra contact points: $CASSANDRA_CONTACT_POINTS"
+source .${STORAGE_TYPE}_profile
 
 if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
   export SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
@@ -17,4 +7,4 @@ if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
 fi
 
 echo "** Starting zipkin query..."
-java -jar zipkin-query.jar -f /query-cassandra.scala
+java -jar zipkin-query.jar -f /query-${STORAGE_TYPE}.scala

--- a/web/run.sh
+++ b/web/run.sh
@@ -4,16 +4,16 @@ if [[ -z $QUERY_PORT_9411_TCP_ADDR ]]; then
   exit 1
 fi
 
-if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
-  export SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
-  export SCRIBE_PORT=9410
-fi
-
 QUERY_ADDR="${QUERY_PORT_9411_TCP_ADDR}:9411"
 SERVICE_NAME="zipkin-web"
 
 DEFAULT_ROOTURL=http://localhost:8080/
 ROOTURL="-zipkin.web.rootUrl=${ROOTURL:-DEFAULT_ROOTURL}"
+
+if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
+  export SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
+  export SCRIBE_PORT=9410
+fi
 
 echo "** Starting zipkin web..."
 # cacheResources implies serving web assets from the jar, as opposed to a local filesystem path


### PR DESCRIPTION
Users can now assign `STORAGE_TYPE` as `cassandra` or `mysql` to start
zipkin on the corresponding backend.

Fixes #56