### PR TITLE
Use openzipkin/jre-full as the base Docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM delitescere/jdk:8
+FROM openzipkin/jre-full:1.8.0_60
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 RUN apk update && apk add netcat-openbsd curl


### PR DESCRIPTION
As an implementation of https://github.com/openzipkin/docker-zipkin/issues/62

Comparing `delitescere/jdk` and `openzipkin/jre-full`: https://imagelayers.io/?images=delitescere%2Fjdk:1.8.0_60,openzipkin%2Fjre-full:1.8.0_60