### PR TITLE
Adds Kafka image and TRANSPORT_TYPE to select it with

### DIFF
--- a/base/.kafka_profile
+++ b/base/.kafka_profile
@@ -1,0 +1,23 @@
+#!/bin/sh
+if [[ -z $KAFKA_ZOOKEEPER ]]; then
+  if [[ -z $KAFKA_PORT_2181_TCP_ADDR ]]; then	
+    echo "** ERROR: You need to link with a Zookeeper container as 'kafka' or specify KAFKA_ZOOKEEPER env var."
+    echo "KAFKA_PORT_2181_TCP_ADDR (container link) or KAFKA_ZOOKEEPER should contain a zookeeper connect string."
+    exit 1
+  fi
+  KAFKA_ZOOKEEPER=$KAFKA_PORT_2181_TCP_ADDR:2181
+fi
+
+if [[ -z $METADATA_BROKER_LIST ]]; then
+  if [[ -z $KAFKA_PORT_9092_TCP_ADDR ]]; then	
+    echo "** ERROR: You need to link with a Kafka container as 'kafka' or specify METADATA_BROKER_LIST env var."
+    echo "KAFKA_PORT_9092_TCP_ADDR (container link) or METADATA_BROKER_LIST should contain a list of kafka hostname:port."
+    exit 1
+  fi
+  METADATA_BROKER_LIST=$KAFKA_PORT_9092_TCP_ADDR:9092
+fi
+
+export KAFKA_ZOOKEEPER
+echo "Kafka Zookeeper: $KAFKA_ZOOKEEPER"
+export METADATA_BROKER_LIST
+echo "Metdata Broker List: $METADATA_BROKER_LIST"

--- a/base/.scribe_profile
+++ b/base/.scribe_profile
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [[ -z $SCRIBE_HOST ]]; then
+  if [[ -z $COLLECTOR_PORT_9410_TCP_ADDR ]]; then	
+    echo "** ERROR: You need to link with a Zipkin Collector container as 'collector' or specify SCRIBE_HOST and SCRIBE_PORT env vars."
+    echo "COLLECTOR_PORT_9410_TCP_ADDR (container link) or SCRIBE_HOST, SCRIBE_PORT must be set."
+    exit 1
+  fi
+  SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
+  SCRIBE_PORT=9410
+fi
+
+export SCRIBE_HOST SCRIBE_PORT
+echo "Scribe: $SCRIBE_HOST:$SCRIBE_PORT"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,8 @@ ENV ZIPKIN_VERSION 1.17.2
 
 RUN mkdir /zipkin
 ADD .cassandra_profile /zipkin/.cassandra_profile
+ADD .kafka_profile /zipkin/.kafka_profile
 ADD .mysql_profile /zipkin/.mysql_profile
+ADD .scribe_profile /zipkin/.scribe_profile
 
 WORKDIR /zipkin

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 source .${STORAGE_TYPE}_profile
 
+# the collector is a scribe listener
+test "$TRANSPORT_TYPE" != 'scribe' && source .${TRANSPORT_TYPE}_profile
+
 echo "** Starting zipkin collector..."
 java -jar zipkin-collector.jar -f /collector-${STORAGE_TYPE}.scala

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -5,6 +5,7 @@ mysql:
 collector:
   image: openzipkin/zipkin-collector:1.17.2
   environment:
+    - TRANSPORT_TYPE=scribe
     - STORAGE_TYPE=mysql
   expose:
     - 9410
@@ -16,6 +17,7 @@ collector:
 query:
   image: openzipkin/zipkin-query:1.17.2
   environment:
+    - TRANSPORT_TYPE=scribe
     - STORAGE_TYPE=mysql
   expose:
     - 9411
@@ -27,6 +29,8 @@ query:
     - collector
 web:
   image: openzipkin/zipkin-web:1.17.2
+  environment:
+    - TRANSPORT_TYPE=scribe
   ports:
     - 8080:8080
     - 9990:9990

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ cassandra:
 collector:
   image: openzipkin/zipkin-collector:1.17.2
   environment:
+    - TRANSPORT_TYPE=scribe
     - STORAGE_TYPE=cassandra
   expose:
     - 9410
@@ -16,6 +17,7 @@ collector:
 query:
   image: openzipkin/zipkin-query:1.17.2
   environment:
+    - TRANSPORT_TYPE=scribe
     - STORAGE_TYPE=cassandra
   expose:
     - 9411
@@ -27,6 +29,8 @@ query:
     - collector
 web:
   image: openzipkin/zipkin-web:1.17.2
+  environment:
+    - TRANSPORT_TYPE=scribe
   ports:
     - 8080:8080
     - 9990:9990

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/openzipkin/zipkin-base:base-1.17.2
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+ENV SCALA_VERSION 2.11
+ENV KAFKA_VERSION 0.8.2.2
+ENV ZOOKEEPER_VERSION 3.4.6
+
+WORKDIR /kafka
+ADD install.sh /kafka/install
+RUN /kafka/install
+
+EXPOSE 2181 9092
+
+CMD ["runsvdir", "/etc/service"]

--- a/kafka/install.sh
+++ b/kafka/install.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eux
+
+echo "*** Installing Kafka and dependencies"
+echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+apk add --update runit
+
+# download and cherry-pick zookeeper binaries
+curl -SL http://mirrors.sonic.net/apache/zookeeper/zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.tar.gz | tar xz
+mkdir zookeeper
+mv zookeeper-$ZOOKEEPER_VERSION/lib zookeeper/
+mv zookeeper-$ZOOKEEPER_VERSION/zookeeper-$ZOOKEEPER_VERSION.jar zookeeper/lib
+mv zookeeper-$ZOOKEEPER_VERSION/conf zookeeper/
+
+# create runit config
+mkdir -p /etc/service/zookeeper
+cat > /etc/service/zookeeper/run <<-EOF
+#!/bin/sh
+exec java -Dzookeeper.log.dir=/kafka/zookeeper -Dzookeeper.root.logger=INFO,CONSOLE -cp /kafka/zookeeper/lib/*:/kafka/zookeeper/conf org.apache.zookeeper.server.quorum.QuorumPeerMain /kafka/zookeeper/conf/zoo_sample.cfg
+EOF
+chmod +x /etc/service/zookeeper/run
+
+# download kafka binaries
+curl -SL http://apache.mirrors.spacedump.net/kafka/$KAFKA_VERSION/kafka_$SCALA_VERSION-$KAFKA_VERSION.tgz | tar xz
+mv kafka_$SCALA_VERSION-$KAFKA_VERSION/* .
+
+# Set explicit, basic configuration
+cat > config/server.properties <<-EOF
+broker.id=0
+port=9092
+zookeeper.connect=127.0.0.1:2181
+replica.socket.timeout.ms=1500
+log.dirs=/kafka/logs
+auto.create.topics.enable=true
+EOF
+
+# create runit config, dependent on zookeeper, that advertises the container ip
+mkdir -p /etc/service/kafka
+cat > /etc/service/kafka/run <<-EOF
+#!/bin/sh
+sv start zookeeper || exit 1
+echo advertised.host.name=$(route -n | awk '/UG[ \t]/{print $2}') >> /kafka/config/server.properties
+exec sh /kafka/bin/kafka-run-class.sh -name kafkaServer -loggc kafka.Kafka /kafka/config/server.properties
+EOF
+chmod +x /etc/service/kafka/run
+
+echo "*** Cleaning Up"
+rm -rf rm -rf /var/cache/apk/*
+rm -rf zookeeper-$ZOOKEEPER_VERSION
+
+echo "*** Image build complete"

--- a/query/run.sh
+++ b/query/run.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 source .${STORAGE_TYPE}_profile
-
-if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
-  export SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
-  export SCRIBE_PORT=9410
-fi
+source .${TRANSPORT_TYPE}_profile
 
 echo "** Starting zipkin query..."
 java -jar zipkin-query.jar -f /query-${STORAGE_TYPE}.scala

--- a/release.sh
+++ b/release.sh
@@ -35,8 +35,8 @@ release_tag="$1"
 base_images="${BASE_IMAGES:-zipkin-base}"
 base_dirs="${BASE_DIRS:-base}"
 # Service images
-service_images="${SERVICE_IMAGES:-zipkin-cassandra zipkin-mysql zipkin-collector zipkin-query zipkin-web}"
-service_dirs="${SERVICE_DIRS:-cassandra mysql collector query web}"
+service_images="${SERVICE_IMAGES:-zipkin-cassandra zipkin-kafka zipkin-mysql zipkin-collector zipkin-query zipkin-web}"
+service_dirs="${SERVICE_DIRS:-cassandra kafka mysql collector query web}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"

--- a/web/run.sh
+++ b/web/run.sh
@@ -4,16 +4,13 @@ if [[ -z $QUERY_PORT_9411_TCP_ADDR ]]; then
   exit 1
 fi
 
+source .${TRANSPORT_TYPE}_profile
+
 QUERY_ADDR="${QUERY_PORT_9411_TCP_ADDR}:9411"
 SERVICE_NAME="zipkin-web"
 
 DEFAULT_ROOTURL=http://localhost:8080/
 ROOTURL="-zipkin.web.rootUrl=${ROOTURL:-DEFAULT_ROOTURL}"
-
-if [ "$COLLECTOR_PORT_9410_TCP_ADDR" ]; then
-  export SCRIBE_HOST=$COLLECTOR_PORT_9410_TCP_ADDR
-  export SCRIBE_PORT=9410
-fi
 
 echo "** Starting zipkin web..."
 # cacheResources implies serving web assets from the jar, as opposed to a local filesystem path


### PR DESCRIPTION
This adds an image for Kafka/Zookeeper, which can be used to test kafka
integration of zipkin with instrumentation including Ruby, Finagle, Brave &
HTrace. This exports a new variable to designate the `TRANSPORT_TYPE`,
with choices of `scribe` and `kafka`.

At the moment, there's no Finagle Kafka integraion. I tested this with
an experimental Brave span transport, used in the `zipkin-java` project.

The image bundles together Kafka and Zookeeper using Runit as the entry-
point. This is for simplicitly and to keep the requirements as small as
possible to run tests (ex. we are already several containers). The
approach used is similar to baseimage-docker.

See https://github.com/openzipkin/brave/issues/102
See https://github.com/apache/incubator-htrace/commit/9ebdafb45df03a4b0d90c77af65e0bd21c09ec1a
See https://github.com/openzipkin/zipkin/issues/682
See http://phusion.github.io/baseimage-docker