### PR TITLE
Migrates zipkin self-tracing off scribe and minifies MySQL example

### DIFF
--- a/base/.http_profile
+++ b/base/.http_profile
@@ -1,0 +1,3 @@
+# Currently, http transport isn't parameterized as zipkin-web explictly uses the
+# zipkin-query host, and zipkin-query logs locally. In the future, we may want
+# to parameterize this, for example, to test load balanced http listeners.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ ENV ZIPKIN_VERSION 1.19.1
 
 RUN mkdir /zipkin
 ADD .cassandra_profile /zipkin/.cassandra_profile
+ADD .http_profile /zipkin/.http_profile
 ADD .kafka_profile /zipkin/.kafka_profile
 ADD .mysql_profile /zipkin/.mysql_profile
 ADD .scribe_profile /zipkin/.scribe_profile

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -2,23 +2,11 @@ mysql:
   image: openzipkin/zipkin-mysql:1.19.1
   ports:
     - 3306:3306
-collector:
-  image: openzipkin/zipkin-collector:1.19.1
-  environment:
-    - TRANSPORT_TYPE=scribe
-    - STORAGE_TYPE=mysql
-  expose:
-    - 9410
-  ports:
-    - 9410:9410
-    - 9900:9900
-  links:
-    - mysql:storage
 query:
   image: openzipkin/zipkin-query:1.19.1
   environment:
-    # Remove TRANSPORT_TYPE and unlink collector to disable tracing
-    - TRANSPORT_TYPE=scribe
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
   expose:
     - 9411
@@ -27,15 +15,13 @@ query:
     - 9901:9901
   links:
     - mysql:storage
-    - collector
 web:
   image: openzipkin/zipkin-web:1.19.1
   environment:
-    # Remove TRANSPORT_TYPE and unlink collector to disable tracing
-    - TRANSPORT_TYPE=scribe
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
   ports:
     - 8080:8080
     - 9990:9990
   links:
-    - collector
     - query

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ cassandra:
   image: openzipkin/zipkin-cassandra:1.19.1
   ports:
     - 9042:9042
+# The collector process is used for legacy zipkin instrumentation, which log via
+# scribe. It can also poll kafka, when the KAFKA_ZOOKEEPER variable is set.
 collector:
   image: openzipkin/zipkin-collector:1.19.1
   environment:
@@ -14,11 +16,13 @@ collector:
     - 9900:9900
   links:
     - cassandra:storage
+# The query process services the UI, and also exposes a POST endpoint that
+# instrumentation can send trace data to.
 query:
   image: openzipkin/zipkin-query:1.19.1
   environment:
-    # Remove TRANSPORT_TYPE and unlink collector to disable tracing
-    - TRANSPORT_TYPE=scribe
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
     - STORAGE_TYPE=cassandra
   expose:
     - 9411
@@ -27,15 +31,13 @@ query:
     - 9901:9901
   links:
     - cassandra:storage
-    - collector
 web:
   image: openzipkin/zipkin-web:1.19.1
   environment:
-    # Remove TRANSPORT_TYPE and unlink collector to disable tracing
-    - TRANSPORT_TYPE=scribe
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
   ports:
     - 8080:8080
     - 9990:9990
   links:
-    - collector
     - query


### PR DESCRIPTION
Before, zipkin required a collector process for the purpose of self-
tracing. Collector is still supported, particularly to serve legacy
instrumentation. However, it is no longer required as zipkin can
self-trace over http.

This change updates the MySQL example (docker-compose-mysql.yml),
showing how self-tracing can work without a collector process.