### PR TITLE
Removes orphaned install of netcat-openbsd

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM openzipkin/jre-full:1.8.0_60
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-RUN apk update && apk add netcat-openbsd curl
+RUN apk update && apk add curl
 
 ENV ZIPKIN_REPO https://jcenter.bintray.com
 ENV ZIPKIN_VERSION 1.25.1


### PR DESCRIPTION
This was added before we got our cassandra story working.