### PR TITLE
Allows customization of JRE via JAVA_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The started Zipkin instance will be backed by a single-node Cassandra.
 All images share a base image, 
 `zipkin-base`, which is built on the Alpine-based image [`delitescere/java:8`] (https://github.com/delitescere/docker-zulu), which is much smaller than the previously used `debian:sid`-based image.
 
+`zipkin-collector`, `zipkin-query`, and `zipkin-web` honor the environment variable `JAVA_OPTS`, which can be used to set heap size, trust store location or other JVM system properties.
+
 ## Connecting to Span Storage
 
 `zipkin-collector` and `zipkin-query` store and retrieve spans from Cassandra, using its native protocol. Specify a list of one or more Cassandra nodes listening on port 9042, via the comma-separated environment variable `CASSANDRA_CONTACT_POINTS`.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,6 +5,9 @@ RUN apk update && apk add curl
 
 ENV ZIPKIN_REPO https://jcenter.bintray.com
 ENV ZIPKIN_VERSION 1.26.0
+# Use to set heap, trust store or other system properties.
+# Intentionally defaulted to empty string.
+ENV JAVA_OPTS=
 
 RUN mkdir /zipkin
 ADD .cassandra_profile /zipkin/.cassandra_profile

--- a/collector/run.sh
+++ b/collector/run.sh
@@ -5,4 +5,4 @@ source .${STORAGE_TYPE}_profile
 test "$TRANSPORT_TYPE" != 'scribe' && source .${TRANSPORT_TYPE}_profile
 
 echo "** Starting zipkin collector..."
-exec java -jar zipkin-collector.jar -f /collector-${STORAGE_TYPE}.scala
+exec java ${JAVA_OPTS} -jar zipkin-collector.jar -f /collector-${STORAGE_TYPE}.scala

--- a/query/run.sh
+++ b/query/run.sh
@@ -3,4 +3,4 @@ source .${STORAGE_TYPE}_profile
 test -n "$TRANSPORT_TYPE" && source .${TRANSPORT_TYPE}_profile
 
 echo "** Starting zipkin query..."
-exec java -jar zipkin-query.jar -f /query-${STORAGE_TYPE}.scala
+exec java ${JAVA_OPTS} -jar zipkin-query.jar -f /query-${STORAGE_TYPE}.scala

--- a/web/run.sh
+++ b/web/run.sh
@@ -14,4 +14,4 @@ ROOTURL="-zipkin.web.rootUrl=${ROOTURL:-DEFAULT_ROOTURL}"
 
 echo "** Starting zipkin web..."
 # cacheResources implies serving web assets from the jar, as opposed to a local filesystem path
-exec java -jar zipkin-web.jar -zipkin.web.cacheResources=true -zipkin.web.query.dest=${QUERY_ADDR} ${ROOTURL}
+exec java ${JAVA_OPTS} -jar zipkin-web.jar -zipkin.web.cacheResources=true -zipkin.web.query.dest=${QUERY_ADDR} ${ROOTURL}


### PR DESCRIPTION
Customizations including heap size or trust stores require modifying JRE
arguments. This adds `JAVA_OPTS`, which can be used to do that.

This is in the base image, so could be used by anything that derives
from it, including zipkin-web, zipkin-query and zipkin-collector.

Ex.
```yaml
  environment:
    - JAVA_OPTS=-Xmx1G
```

See https://github.com/openzipkin/zipkin/issues/885