### PR TITLE
Use overrides for docker-compose mysql setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,38 @@ Dockerfiles for starting a Zipkin instance backed by Cassandra. Automatically bu
 under the [OpenZipkin](https://quay.io/organization/openzipkin) organization, and are mirrored to
 [Docker Hub](https://hub.docker.com/u/openzipkin/).
 
-## Running
+## docker-compose
 
-Use [docker-compose](https://docs.docker.com/compose/) by doing
-`docker-compose up`.
+This project is configured to run docker containers using
+[docker-compose](https://docs.docker.com/compose/).
+
+To start the default docker-compose configuration, run:
+
+    $ docker-compose up
 
 See the ui at (docker ip):8080
 
 In the ui - click zipkin-query, then click "Find Traces"
 
+### Cassandra
+
+The default docker-compose configuration defined in `docker-compose.yml` is
+backed by a single-node Cassandra. This configuration starts each of the Zipkin
+services in their own containers: `zipkin-cassandra`, `zipkin-collector`,
+`zipkin-query`, and `zipkin-web`, and only links required dependencies together.
+
+### MySQL
+
+The docker-compose configuration can be extended to use MySQL instead of
+Cassandra, using the `docker-compose-mysql.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to swap out one storage container for another.
+
+To start the MySQL-backed configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-mysql.yml up
+
 ## Notes
-
-Docker-Zipkin starts each of the services in their own containers: `zipkin-cassandra`,
-`zipkin-collector`, `zipkin-query`, and `zipkin-web`, and only link required dependencies
-together.
-
-The started Zipkin instance will be backed by a single-node Cassandra.
 
 All images share a base image, 
 `zipkin-base`, which is built on the Alpine-based image [`delitescere/java:8`] (https://github.com/delitescere/docker-zulu), which is much smaller than the previously used `debian:sid`-based image.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ In the ui - click zipkin-query, then click "Find Traces"
 
 The default docker-compose configuration defined in `docker-compose.yml` is
 backed by a single-node Cassandra. This configuration starts each of the Zipkin
-services in their own containers: `zipkin-cassandra`, `zipkin-collector`,
-`zipkin-query`, and `zipkin-web`, and only links required dependencies together.
+services in their own containers: `zipkin-cassandra`, `zipkin-query`, and
+`zipkin-web`, and only links required dependencies together.
 
 ### MySQL
 

--- a/base/.cassandra_profile
+++ b/base/.cassandra_profile
@@ -1,8 +1,9 @@
 #!/bin/sh
 if [[ -z $CASSANDRA_CONTACT_POINTS ]]; then
-  if [[ -z $STORAGE_PORT_9042_TCP_ADDR ]]; then	
+  if [[ -z $STORAGE_PORT_9042_TCP_ADDR ]]; then
     echo "** ERROR: You need to link with a Cassandra container as 'storage' or specify CASSANDRA_CONTACT_POINTS env var."
     echo "STORAGE_PORT_9042_TCP_ADDR (container link) or CASSANDRA_CONTACT_POINTS should contain a comma separated list of Cassandra contact points."
+    exit 1
   fi
   CASSANDRA_CONTACT_POINTS=$STORAGE_PORT_9042_TCP_ADDR
 fi

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -5,12 +5,6 @@ storage:
     - 3306:3306
 
 # Switch storage type to MySQL
-collector:
-  environment:
-    - TRANSPORT_TYPE=scribe
-    - STORAGE_TYPE=mysql
-
-# Switch storage type to MySQL
 query:
   environment:
     - TRANSPORT_TYPE=http

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,37 +1,17 @@
-mysql:
+# Run MySQL instead of Cassandra
+storage:
   image: openzipkin/zipkin-mysql:1.37.0
   ports:
     - 3306:3306
-query:
-  image: openzipkin/zipkin-query:1.37.0
+
+# Switch storage type to MySQL
+collector:
   environment:
-    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=scribe
+    - STORAGE_TYPE=mysql
+
+# Switch storage type to MySQL
+query:
+  environment:
     - TRANSPORT_TYPE=http
     - STORAGE_TYPE=mysql
-  expose:
-    # The http api is mounted at /api/v1
-    - 9411
-    # Admin interface is under the http path /admin
-    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
-    - 9901
-  ports:
-    - 9411:9411
-    - 9901:9901
-  links:
-    - mysql:storage
-web:
-  image: openzipkin/zipkin-web:1.37.0
-  environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
-  expose:
-    # Web UI is mounted at the root, and the http api under /api/v1
-    - 8080
-    # Admin interface is under the http path /admin
-    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
-    - 9990
-  ports:
-    - 8080:8080
-    - 9990:9990
-  links:
-    - query

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,25 +3,6 @@ storage:
   ports:
     - 9042:9042
 
-# The collector process is used for legacy zipkin instrumentation, which log via
-# scribe. It can also poll kafka, when the KAFKA_ZOOKEEPER variable is set.
-collector:
-  image: openzipkin/zipkin-collector:1.37.0
-  environment:
-    - TRANSPORT_TYPE=scribe
-    - STORAGE_TYPE=cassandra
-  expose:
-    # The scribe thrift api listens on this port
-    - 9410
-    # Admin interface is under the http path /admin
-    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
-    - 9900
-  ports:
-    - 9410:9410
-    - 9900:9900
-  links:
-    - storage
-
 # The query process services the UI, and also exposes a POST endpoint that
 # instrumentation can send trace data to.
 query:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-cassandra:
+storage:
   image: openzipkin/zipkin-cassandra:1.37.0
   ports:
     - 9042:9042
+
 # The collector process is used for legacy zipkin instrumentation, which log via
 # scribe. It can also poll kafka, when the KAFKA_ZOOKEEPER variable is set.
 collector:
@@ -19,7 +20,8 @@ collector:
     - 9410:9410
     - 9900:9900
   links:
-    - cassandra:storage
+    - storage
+
 # The query process services the UI, and also exposes a POST endpoint that
 # instrumentation can send trace data to.
 query:
@@ -38,7 +40,8 @@ query:
     - 9411:9411
     - 9901:9901
   links:
-    - cassandra:storage
+    - storage
+
 web:
   image: openzipkin/zipkin-web:1.37.0
   environment:

--- a/web/run.sh
+++ b/web/run.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
-if [[ -z $QUERY_PORT_9411_TCP_ADDR ]]; then
-  echo "** ERROR: You need to link the query service as query."
-  exit 1
+if [[ -z $QUERY_ADDR ]]; then
+  if [[ -z $QUERY_PORT_9411_TCP_ADDR ]]; then
+    echo "** ERROR: You need to link the query service as 'query' or specify QUERY_ADDR env var."
+    exit 1
+  fi
+  QUERY_ADDR="${QUERY_PORT_9411_TCP_ADDR}:9411"
 fi
 
 test -n "$TRANSPORT_TYPE" && source .${TRANSPORT_TYPE}_profile
-
-QUERY_ADDR="${QUERY_PORT_9411_TCP_ADDR}:9411"
 
 echo "** Starting zipkin web..."
 exec java ${JAVA_OPTS} -jar zipkin-web.jar -zipkin.web.query.dest=${QUERY_ADDR}


### PR DESCRIPTION
The docker-compose-mysql.yml file appears to be incomplete, as it is not
running the collector container. This branch switches that configuration
to be an extention of the default docker-compose.yml file, using
docker-compose overrides, described here:

https://docs.docker.com/compose/extends/#multiple-compose-files

In addition, I've fixed an issue where the zipkin-cassandra container
would not exit if the storage type was not configured correctly. And
I've modified the zipkin-web container to allow overriding the query
service address without requiring linking.