### PR TITLE
Switch to docker-compose v2 configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ To start the MySQL-backed configuration, run:
 
     $ docker-compose -f docker-compose.yml -f docker-compose-mysql.yml up
 
+### Legacy
+
+The Cassandra and MySQL docker-compose files described above use version 2 of
+the docker-compose config file format. There is a legacy version 1 configuration
+also available, in the `docker-compose-legacy.yml` file. That configuration
+relies on container linking, and runs the legacy `zipkin-collector` container.
+
+To start the legacy configuration, run:
+
+    $ docker-compose -f docker-compose-legacy.yml up
+
 ## Notes
 
-All images share a base image, 
+All images share a base image,
 `zipkin-base`, which is built on the Alpine-based image [`delitescere/java:8`] (https://github.com/delitescere/docker-zulu), which is much smaller than the previously used `debian:sid`-based image.
 
 `zipkin-collector`, `zipkin-query`, and `zipkin-web` honor the environment variable `JAVA_OPTS`, which can be used to set heap size, trust store location or other JVM system properties.
@@ -53,7 +64,7 @@ All images share a base image,
 
 `zipkin-collector` and `zipkin-query` store and retrieve spans from Cassandra, using its native protocol. Specify a list of one or more Cassandra nodes listening on port 9042, via the comma-separated environment variable `CASSANDRA_CONTACT_POINTS`.
 
-ex. 
+ex.
 ```bash
 docker run -d -p 9410:9410 -p 9900:9900 --name="zipkin-collector" -e "CASSANDRA_CONTACT_POINTS=node1,node2,node3" "openzipkin/zipkin-collector:latest"
 ```

--- a/docker-compose-legacy.yml
+++ b/docker-compose-legacy.yml
@@ -1,0 +1,67 @@
+# This file uses the version 1 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-1
+#
+# It runs the zipkin-cassandra, zipkin-query, and zipkin-web containers, as well
+# as the legacy zipkin-collector container, and uses docker container linking to
+# wire the containers together.
+
+storage:
+  image: openzipkin/zipkin-cassandra:1.38.1
+  ports:
+    - 9042:9042
+
+# The collector process is used for legacy zipkin instrumentation, which log via
+# scribe. It can also poll kafka, when the KAFKA_ZOOKEEPER variable is set.
+collector:
+  image: openzipkin/zipkin-collector:1.38.1
+  environment:
+    - TRANSPORT_TYPE=scribe
+    - STORAGE_TYPE=cassandra
+  expose:
+    # The scribe thrift api listens on this port
+    - 9410
+    # Admin interface is under the http path /admin
+    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
+    - 9900
+  ports:
+    - 9410:9410
+    - 9900:9900
+  links:
+    - storage
+
+# The query process services the UI, and also exposes a POST endpoint that
+# instrumentation can send trace data to.
+query:
+  image: openzipkin/zipkin-query:1.38.1
+  environment:
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
+    - STORAGE_TYPE=cassandra
+  expose:
+    # The http api is mounted at /api/v1
+    - 9411
+    # Admin interface is under the http path /admin
+    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
+    - 9901
+  ports:
+    - 9411:9411
+    - 9901:9901
+  links:
+    - storage
+
+web:
+  image: openzipkin/zipkin-web:1.38.1
+  environment:
+    # Remove TRANSPORT_TYPE to disable tracing
+    - TRANSPORT_TYPE=http
+  expose:
+    # Web UI is mounted at the root, and the http api under /api/v1
+    - 8080
+    # Admin interface is under the http path /admin
+    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
+    - 9990
+  ports:
+    - 8080:8080
+    - 9990:9990
+  links:
+    - query

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,11 +1,24 @@
-# Run MySQL instead of Cassandra
-storage:
-  image: openzipkin/zipkin-mysql:1.37.0
-  ports:
-    - 3306:3306
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-mysql container instead of the zipkin-cassandra container.
 
-# Switch storage type to MySQL
-query:
-  environment:
-    - TRANSPORT_TYPE=http
-    - STORAGE_TYPE=mysql
+version: '2'
+
+services:
+  # Run MySQL instead of Cassandra
+  storage:
+    image: openzipkin/zipkin-mysql:1.38.1
+    container_name: mysql
+    ports:
+      - 3306:3306
+
+  # Switch storage type to MySQL
+  query:
+    environment:
+      # Remove TRANSPORT_TYPE to disable tracing
+      - TRANSPORT_TYPE=http
+      - STORAGE_TYPE=mysql
+      # Point the query service at the storage backend
+      - MYSQL_HOST=mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,48 @@
-storage:
-  image: openzipkin/zipkin-cassandra:1.37.0
-  ports:
-    - 9042:9042
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It runs the zipkin-cassandra, zipkin-query, and zipkin-web containers, and
+# uses docker-compose's default networking to wire the containers together.
 
-# The query process services the UI, and also exposes a POST endpoint that
-# instrumentation can send trace data to.
-query:
-  image: openzipkin/zipkin-query:1.37.0
-  environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
-    - STORAGE_TYPE=cassandra
-  expose:
-    # The http api is mounted at /api/v1
-    - 9411
-    # Admin interface is under the http path /admin
-    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
-    - 9901
-  ports:
-    - 9411:9411
-    - 9901:9901
-  links:
-    - storage
+version: '2'
 
-web:
-  image: openzipkin/zipkin-web:1.37.0
-  environment:
-    # Remove TRANSPORT_TYPE to disable tracing
-    - TRANSPORT_TYPE=http
-  expose:
-    # Web UI is mounted at the root, and the http api under /api/v1
-    - 8080
-    # Admin interface is under the http path /admin
-    # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
-    - 9990
-  ports:
-    - 8080:8080
-    - 9990:9990
-  links:
-    - query
+services:
+  storage:
+    image: openzipkin/zipkin-cassandra:1.38.1
+    container_name: cassandra
+    ports:
+      - 9042:9042
+
+  # The query process services the UI, and also exposes a POST endpoint that
+  # instrumentation can send trace data to.
+  query:
+    image: openzipkin/zipkin-query:1.38.1
+    container_name: query
+    environment:
+      # Remove TRANSPORT_TYPE to disable tracing
+      - TRANSPORT_TYPE=http
+      - STORAGE_TYPE=cassandra
+      # Point the query service at the storage backend
+      - CASSANDRA_CONTACT_POINTS=cassandra
+    ports:
+      # The http api is mounted at /api/v1
+      - 9411:9411
+      # Admin interface is under the http path /admin
+      # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
+      - 9901:9901
+    depends_on:
+      - storage
+
+  web:
+    image: openzipkin/zipkin-web:1.38.1
+    environment:
+      # Remove TRANSPORT_TYPE to disable tracing
+      - TRANSPORT_TYPE=http
+      # Point the web service at the query backend
+      - QUERY_ADDR=query:9411
+    ports:
+      # Web UI is mounted at the root, and the http api under /api/v1
+      - 8080:8080
+      # Admin interface is under the http path /admin
+      # https://twitter.github.io/twitter-server/Features.html#http-admin-interface
+      - 9990:9990


### PR DESCRIPTION
Convert the docker-compose.yml and docker-compose-mysql.yml files to use
the version 2 docker-compose file format, as described here:

https://docs.docker.com/compose/compose-file/#version-2

The v1 configuration is still available in the docker-compose-legacy.yml
file, and I've re-added the collector container to that configuration,
since it is now denoted to be legacy.