### PR TITLE
Add runtime configuration section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,33 @@
 [![zipkin-query](https://quay.io/repository/openzipkin/zipkin-query/status "zipkin-query")](https://quay.io/repository/openzipkin/zipkin-query)
 [![zipkin-web](https://quay.io/repository/openzipkin/zipkin-web/status "zipkin-web")](https://quay.io/repository/openzipkin/zipkin-web)
 
-Dockerfiles for starting a Zipkin instance backed by Cassandra. Automatically built images are available on Quay.io
-under the [OpenZipkin](https://quay.io/organization/openzipkin) organization, and are mirrored to
-[Docker Hub](https://hub.docker.com/u/openzipkin/).
+This project contains Dockerfiles for producing images for each of the
+components in a full Zipkin stack.  Automatically built images are available on
+Quay.io under the [OpenZipkin](https://quay.io/organization/openzipkin) organization,
+and are mirrored to [Docker Hub](https://hub.docker.com/u/openzipkin/).
 
 ## docker-compose
 
 This project is configured to run docker containers using
-[docker-compose](https://docs.docker.com/compose/).
+[docker-compose](https://docs.docker.com/compose/). Note that the default
+configuration requires docker-compose 1.6.0+ and docker-engine 1.10.0+. If you
+are running older versions, see the [Legacy](#legacy) section below.
 
 To start the default docker-compose configuration, run:
 
     $ docker-compose up
 
-See the ui at (docker ip):8080
+View the web UI at $(docker ip):8080.
 
-In the ui - click zipkin-query, then click "Find Traces"
+To see specific traces in the UI, select "zipkin-query" in the dropdown and
+then click the "Find Traces" button.
 
 ### Cassandra
 
 The default docker-compose configuration defined in `docker-compose.yml` is
 backed by a single-node Cassandra. This configuration starts each of the Zipkin
 services in their own containers: `zipkin-cassandra`, `zipkin-query`, and
-`zipkin-web`, and only links required dependencies together.
+`zipkin-web`, and configures required dependencies.
 
 ### MySQL
 
@@ -53,18 +57,73 @@ To start the legacy configuration, run:
 
     $ docker-compose -f docker-compose-legacy.yml up
 
+## Runtime configuration
+
+Most runtime configuration is handled with environment variables. Some of the
+available environment variables are not docker-specific, and as such they are
+documented in the main Zipkin repo, as follows:
+
+* [zipkin-cassandra](https://github.com/openzipkin/zipkin/tree/master/zipkin-cassandra#service-configuration)
+* [zipkin-collector](https://github.com/openzipkin/zipkin/blob/master/zipkin-collector-service/README.md#configuration)
+* [zipkin-query](https://github.com/openzipkin/zipkin/blob/master/zipkin-query-service/README.md#configuration)
+* [zipkin-web](https://github.com/openzipkin/zipkin/blob/master/zipkin-web/README.md#configuration)
+
+Additionally, docker-specific environment variables are described below. See the
+docker-compose files for additional examples of how these variables may be set.
+
+### Storage
+
+Both the `zipkin-query` and the `zipkin-collector` containers need to be
+configured to talk to a storage. The backend is determined by the `STORAGE_TYPE`
+environment variable, and the available values are "cassandra" or "mysql".
+
+If `STORAGE_TYPE=cassandra`, then the container expects for one of these two
+additional environment variables to be set:
+
+* `CASSANDRA_CONTACT_POINTS` -- A comma-separated list of one or more Cassandra
+  nodes listening on port 9042.
+* `STORAGE_PORT_9042_TCP_ADDR` -- A Cassandra node listening on port 9042. This
+  environment variable is typically set by linking a container running
+  `zipkin-cassandra` as "storage" when you start the container.
+
+If `STORAGE_TYPE=mysql`, then the container expects for one of these two
+additional environment variables to be set:
+
+* `MYSQL_HOST` -- A MySQL node listening on port 3306.
+* `STORAGE_PORT_3306_TCP_ADDR` -- A MySQL node listening on port 3306. This
+  environment variable is typically set by linking a container running
+  `zipkin-mysql` as "storage" when you start the container.
+
+### Transport
+
+The `zipkin-query`, `zipkin-collector` and `zipkin-web` containers use the
+`TRANSPORT_TYPE` environment variable to configure how they send and receive
+data.
+
+For the query and web containers, if `TRANSPORT_TYPE=http`, then those
+containers will send trace data via http to the `zipkin-query` service. If
+`TRANSPORT_TYPE=scribe`, then  those containers will send trace data via scribe
+to the `zipkin-collector` service. If `TRANSPORT_TYPE` is unset, then those
+containers will not trace requests that they receive.
+
+For the collector container, if `TRANSPORT_TYPE=scribe`, then the container will
+run a scribe collector on port 9410. If `TRANSPORT_TYPE=kafka`, then the
+container will poll Kafka, and expects one of these two additional environment
+variables to be set:
+
+* `KAFKA_ZOOKEEPER` -- A node and port where Zookeeper is running.
+* `KAFKA_PORT_2181_TCP_ADDR` -- A zookeeper node listening on port 2181. This
+  environment variable is typically set by linking a container running
+  `zipkin-kafka` as "kafka" when you start the container.
+
+### JAVA_OPTS
+
+The `zipkin-collector`, `zipkin-query`, and `zipkin-web` containers honor the
+`JAVA_OPTS` environment variable, which can be used to set heap size, trust
+store location or other JVM system properties.
+
 ## Notes
 
-All images share a base image,
-`zipkin-base`, which is built on the Alpine-based image [`delitescere/java:8`] (https://github.com/delitescere/docker-zulu), which is much smaller than the previously used `debian:sid`-based image.
-
-`zipkin-collector`, `zipkin-query`, and `zipkin-web` honor the environment variable `JAVA_OPTS`, which can be used to set heap size, trust store location or other JVM system properties.
-
-## Connecting to Span Storage
-
-`zipkin-collector` and `zipkin-query` store and retrieve spans from Cassandra, using its native protocol. Specify a list of one or more Cassandra nodes listening on port 9042, via the comma-separated environment variable `CASSANDRA_CONTACT_POINTS`.
-
-ex.
-```bash
-docker run -d -p 9410:9410 -p 9900:9900 --name="zipkin-collector" -e "CASSANDRA_CONTACT_POINTS=node1,node2,node3" "openzipkin/zipkin-collector:latest"
-```
+All images share a base image, `zipkin-base`, which is built on the Alpine-based
+image [`delitescere/java:8`](https://github.com/delitescere/docker-zulu), which
+is much smaller than the previously used `debian:sid`-based image.

--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ documented in the main Zipkin repo, as follows:
 * [zipkin-web](https://github.com/openzipkin/zipkin/blob/master/zipkin-web/README.md#configuration)
 
 Additionally, docker-specific environment variables are described below. See the
-docker-compose files for additional examples of how these variables may be set.
+docker-compose files for examples of how these variables may be set.
 
-### Storage
+### STORAGE_TYPE
 
 Both the `zipkin-query` and the `zipkin-collector` containers need to be
-configured to talk to a storage. The backend is determined by the `STORAGE_TYPE`
-environment variable, and the available values are "cassandra" or "mysql".
+configured to talk to a storage backend. The backend is determined by the
+`STORAGE_TYPE` environment variable. The currently available storage types are
+"cassandra" or "mysql".
 
 If `STORAGE_TYPE=cassandra`, then the container expects for one of these two
 additional environment variables to be set:
@@ -94,22 +95,22 @@ additional environment variables to be set:
   environment variable is typically set by linking a container running
   `zipkin-mysql` as "storage" when you start the container.
 
-### Transport
+### TRANSPORT_TYPE
 
-The `zipkin-query`, `zipkin-collector` and `zipkin-web` containers use the
+The `zipkin-query`, `zipkin-web`, and `zipkin-collector` containers use the
 `TRANSPORT_TYPE` environment variable to configure how they send and receive
 data.
 
-For the query and web containers, if `TRANSPORT_TYPE=http`, then those
-containers will send trace data via http to the `zipkin-query` service. If
-`TRANSPORT_TYPE=scribe`, then  those containers will send trace data via scribe
-to the `zipkin-collector` service. If `TRANSPORT_TYPE` is unset, then those
-containers will not trace requests that they receive.
+For the query and web containers, if `TRANSPORT_TYPE=http`, then the container
+will send trace data via http to the `zipkin-query` service. If
+`TRANSPORT_TYPE=scribe`, then  the container will send trace data via scribe to
+the `zipkin-collector` service. If `TRANSPORT_TYPE` is unset, then the container
+will not trace requests that they receive.
 
 For the collector container, if `TRANSPORT_TYPE=scribe`, then the container will
 run a scribe collector on port 9410. If `TRANSPORT_TYPE=kafka`, then the
-container will poll Kafka, and expects one of these two additional environment
-variables to be set:
+container will also poll Kafka, and expects one of these two additional
+environment variables to be set:
 
 * `KAFKA_ZOOKEEPER` -- A node and port where Zookeeper is running.
 * `KAFKA_PORT_2181_TCP_ADDR` -- A zookeeper node listening on port 2181. This


### PR DESCRIPTION
This branch updates the README with info about docker-specific environment variables that can be set to control a running docker container. I've also included links back to the Zipkin documentation of other available environment variables where appropriate. And I've added information about the minimum versions of docker / docker-compose required to run the v2 docker-compose files. I'm not super familiar with how all of the containers are configured, so please correct if I've made any mistakes.