### PR TITLE
Adds a basic Elasticsearch image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![zipkin](https://quay.io/repository/openzipkin/zipkin/status "zipkin")](https://quay.io/repository/openzipkin/zipkin)
 [![zipkin-cassandra](https://quay.io/repository/openzipkin/zipkin-cassandra/status "zipkin-cassandra")](https://quay.io/repository/openzipkin/zipkin-cassandra)
 [![zipkin-mysql](https://quay.io/repository/openzipkin/zipkin-mysql/status "zipkin-mysql")](https://quay.io/repository/openzipkin/zipkin-mysql)
+[![zipkin-elasticsearch](https://quay.io/repository/openzipkin/zipkin-elasticsearch/status "zipkin-elasticsearch")](https://quay.io/repository/openzipkin/zipkin-elasticsearch)
 [![zipkin-kafka](https://quay.io/repository/openzipkin/zipkin-kafka/status "zipkin-kafka")](https://quay.io/repository/openzipkin/zipkin-kafka)
 
 
@@ -36,6 +37,9 @@ When in docker, the following environment variables also apply
 * `STORAGE_PORT_3306_TCP_ADDR` -- A MySQL node listening on port 3306. This
   environment variable is typically set by linking a container running
   `zipkin-mysql` as "storage" when you start the container.
+* `STORAGE_PORT_9300_TCP_ADDR` -- An Elasticsearch node listening on port 9300. This
+  environment variable is typically set by linking a container running
+  `zipkin-elasticsearch` as "storage" when you start the container.
 * `KAFKA_PORT_2181_TCP_ADDR` -- A zookeeper node listening on port 2181. This
   environment variable is typically set by linking a container running
   `zipkin-kafka` as "kafka" when you start the container.
@@ -74,6 +78,17 @@ To start the MySQL-backed configuration, run:
 
     $ docker-compose -f docker-compose.yml -f docker-compose-mysql.yml up
 
+### Elasticsearch
+
+The docker-compose configuration can be extended to use Elasticsearch instead of
+Cassandra, using the `docker-compose-elasticsearch.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to swap out one storage container for another.
+
+To start the Elasticsearch-backed configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-elasticsearch.yml up
+
 ### Kafka
 
 The docker-compose configuration can be extended to host a test Kafka broker
@@ -90,10 +105,9 @@ you would use for the broker IP when configuring application instrumentation.
 
 ### Legacy
 
-The Cassandra and MySQL docker-compose files described above use version 2 of
-the docker-compose config file format. There is a legacy version 1 configuration
-also available, in the `docker-compose-legacy.yml` file. That configuration
-relies on container linking.
+The docker-compose files described above use version 2 of the docker-compose
+config file format. There is a legacy version 1 configuration also available, in
+`docker-compose-legacy.yml`. That configuration relies on container linking.
 
 To start the legacy configuration, run:
 

--- a/docker-compose-elasticsearch.yml
+++ b/docker-compose-elasticsearch.yml
@@ -1,0 +1,26 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml to run the
+# zipkin-elasticsearch container instead of the zipkin-cassandra container.
+
+version: '2'
+
+services:
+  # Run Elasticsearch instead of Cassandra
+  storage:
+    image: openzipkin/zipkin-elasticsearch:1.4.3
+    container_name: elasticsearch
+    ports:
+      # http
+      - 9200:9200
+      # transport
+      - 9300:9300
+
+  # Switch storage type to Elasticsearch
+  zipkin:
+    image: openzipkin/zipkin:1.4.3
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      # Point the zipkin at the storage backend
+      - ES_HOSTS=elasticsearch

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,32 @@
+#
+# Copyright 2015-2016 The OpenZipkin Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+FROM openzipkin/jre-full:1.8.0_72
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+ENV ELASTICSEARCH_VERSION 2.3.4
+
+WORKDIR /elasticsearch
+
+# single layer to install elasticsearch and the user
+RUN curl -SL https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ELASTICSEARCH_VERSION/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz| tar xz && \
+    mv elasticsearch-$ELASTICSEARCH_VERSION/* /elasticsearch/ && \
+    adduser -S elasticsearch && \
+    chown -R elasticsearch /elasticsearch
+
+# elasticsearch complains if run as root
+USER elasticsearch
+
+EXPOSE 9200 9300
+
+CMD /elasticsearch/bin/elasticsearch -Des.network.host=0.0.0.0

--- a/release.sh
+++ b/release.sh
@@ -32,8 +32,8 @@ started_at=$($date +%s)
 ## Read input and env
 release_tag="$1"
 # Service images
-images="${IMAGES:-zipkin-cassandra zipkin-kafka zipkin-mysql zipkin}"
-dirs="${DIRS:-cassandra kafka mysql zipkin}"
+images="${IMAGES:-zipkin-cassandra zipkin-elasticsearch zipkin-kafka zipkin-mysql zipkin}"
+dirs="${DIRS:-cassandra elasticsearch kafka mysql zipkin}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"

--- a/zipkin/zipkin/.elasticsearch_profile
+++ b/zipkin/zipkin/.elasticsearch_profile
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [[ -z $ES_HOSTS ]]; then
+  if [[ -z $STORAGE_PORT_9300_TCP_ADDR ]]; then
+    echo "** ERROR: You need to link with a Elasticsearch container as 'storage' or specify ES_HOSTS env var."
+    echo "STORAGE_PORT_9300_TCP_ADDR (container link) or ES_HOSTS should contain a Elasticsearch hostname."
+    exit 1
+  fi
+  ES_HOSTS=$STORAGE_PORT_9300_TCP_ADDR
+fi
+
+export ES_HOSTS
+
+echo "Elasticsearch hosts: $ES_HOSTS"


### PR DESCRIPTION
This adds a test image for Elasticsearch, similar to how we have for
Cassandra and MySQL. This completes parity, as we now have a test image
for all supported storage types.