### PR TITLE
Adds dependencies cron job to docker-compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ then click the "Find Traces" button.
 ### Cassandra
 
 The default docker-compose configuration defined in `docker-compose.yml` is
-backed by a single-node Cassandra. This configuration starts `zipkin` and
-`zipkin-cassandra` services in their own containers and configures required
-dependencies.
+backed by a single-node Cassandra. This configuration starts `zipkin`,
+`zipkin-cassandra` and `zipkin-dependencies` (cron job) in their own containers.
 
 ### MySQL
 

--- a/docker-compose-elasticsearch.yml
+++ b/docker-compose-elasticsearch.yml
@@ -24,3 +24,7 @@ services:
       - STORAGE_TYPE=elasticsearch
       # Point the zipkin at the storage backend
       - ES_HOSTS=elasticsearch
+  dependencies:
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      - ES_HOSTS=elasticsearch

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -21,3 +21,7 @@ services:
       - STORAGE_TYPE=mysql
       # Point the zipkin at the storage backend
       - MYSQL_HOST=mysql
+  dependencies:
+    environment:
+      - STORAGE_TYPE=mysql
+      - MYSQL_HOST=mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     container_name: cassandra
     ports:
       - 9042:9042
+
   # The zipkin process services the UI, and also exposes a POST endpoint that
   # instrumentation can send trace data to. Scribe is enabled by default.
   zipkin:
@@ -32,5 +33,17 @@ services:
       - 9411:9411
       # Zipkin UI used to be on a separate process listening on port 8080
       - 8080:9411
+    depends_on:
+      - storage
+
+  # Adds a cron to process spans since midnight every hour, and all spans each day
+  # This data is served by http://192.168.99.100:8080/dependency
+  dependencies:
+    image: openzipkin/zipkin-dependencies
+    container_name: dependencies
+    entrypoint: crond -f -d 8
+    environment:
+      - STORAGE_TYPE=cassandra
+      - CASSANDRA_CONTACT_POINTS=cassandra
     depends_on:
       - storage


### PR DESCRIPTION
This adds another service which runs the [dependencies job](https://github.com/openzipkin/docker-zipkin-dependencies) via cron.

Fixes #75
Fixes #76