### PR TITLE
Adds zipkin-ui image using NGINX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![zipkin-mysql](https://quay.io/repository/openzipkin/zipkin-mysql/status "zipkin-mysql")](https://quay.io/repository/openzipkin/zipkin-mysql)
 [![zipkin-elasticsearch](https://quay.io/repository/openzipkin/zipkin-elasticsearch/status "zipkin-elasticsearch")](https://quay.io/repository/openzipkin/zipkin-elasticsearch)
 [![zipkin-kafka](https://quay.io/repository/openzipkin/zipkin-kafka/status "zipkin-kafka")](https://quay.io/repository/openzipkin/zipkin-kafka)
+[![zipkin-ui](https://quay.io/repository/openzipkin/zipkin-ui/status "zipkin-ui")](https://quay.io/repository/openzipkin/zipkin-ui)
 
 
 This repository contains the Docker build definition and release process for
@@ -122,6 +123,21 @@ To start the MySQL+Kafka configuration, run:
 
 By default, this assumes your Docker host IP is 192.168.99.100, which is what
 you would use for the broker IP when configuring application instrumentation.
+
+### UI
+
+The docker-compose configuration can be extended to host the UI on port 80
+using the `docker-compose-ui.yml` file. That file employs
+[docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
+to add an NGINX container and relevant settings.
+
+To start the NGINX configuration, run:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-ui.yml up
+
+This container doubles as a skeleton for creating proxy configuration around
+Zipkin like authentication, dealing with CORS with zipkin-js apps, or
+terminating SSL. 
 
 ### Legacy
 

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -1,8 +1,8 @@
 # This file uses the version 2 docker-compose file format, described here:
 # https://docs.docker.com/compose/compose-file/#version-2
 #
-# It extends the default configuration from docker-compose.yml to run the
-# zipkin-mysql container instead of the zipkin-cassandra container.
+# It extends the default configuration from docker-compose.yml to add a test
+# kafka server, which is used as a span transport.
 
 version: '2'
 

--- a/docker-compose-ui.yml
+++ b/docker-compose-ui.yml
@@ -1,0 +1,16 @@
+# This file uses the version 2 docker-compose file format, described here:
+# https://docs.docker.com/compose/compose-file/#version-2
+#
+# It extends the default configuration from docker-compose.yml, hosting the
+# ui on port 80 using NGINX
+
+version: '2'
+
+services:
+  zipkin-ui:
+    build: zipkin-ui
+    container_name: zipkin-ui
+    ports:
+      - 80:80
+    depends_on:
+      - zipkin

--- a/release.sh
+++ b/release.sh
@@ -32,8 +32,8 @@ started_at=$($date +%s)
 ## Read input and env
 release_tag="$1"
 # Service images
-images="${IMAGES:-zipkin-cassandra zipkin-elasticsearch zipkin-kafka zipkin-mysql zipkin}"
-dirs="${DIRS:-cassandra elasticsearch kafka mysql zipkin}"
+images="${IMAGES:-zipkin-cassandra zipkin-elasticsearch zipkin-kafka zipkin-ui zipkin-mysql zipkin}"
+dirs="${DIRS:-cassandra elasticsearch kafka ui mysql zipkin}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"

--- a/zipkin-ui/Dockerfile
+++ b/zipkin-ui/Dockerfile
@@ -1,0 +1,19 @@
+FROM nginx:alpine
+
+ENV ZIPKIN_REPO https://jcenter.bintray.com
+ENV ZIPKIN_VERSION 1.12.1
+
+RUN apk add --update --no-cache nginx curl && \
+    rm -rf /var/cache/apk/* /tmp/* /var/tmp/* && \
+    # the current version of zipkin-ui is in a path of the same name in a jar file. This extracts it.
+    curl -SL $ZIPKIN_REPO/io/zipkin/java/zipkin-ui/$ZIPKIN_VERSION/zipkin-ui-$ZIPKIN_VERSION.jar > zipkin-ui.jar && \
+    unzip zipkin-ui.jar 'zipkin-ui/*' -d /var/www/ && \
+    mv /var/www/zipkin-ui /var/www/html && \
+    rm -rf zipkin-ui zipkin-ui.jar
+
+# Setup services
+ADD nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+CMD ["nginx"]

--- a/zipkin-ui/nginx.conf
+++ b/zipkin-ui/nginx.conf
@@ -1,0 +1,81 @@
+user  nginx nginx;
+worker_processes  2;
+
+error_log  /dev/stderr warn;
+pid        /var/run/nginx.pid;
+
+daemon off;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/stdout  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+    gzip_types    application/javascript application/json text/css;
+
+    server_tokens off;
+
+    types {
+        application/font-woff2  woff2;
+    }
+
+    server {
+        listen  80;
+
+        root /var/www/html;
+        index index.html;
+
+        # Make site accessible from http://set-ip-address.xip.io
+        server_name localhost;
+
+        charset utf-8;
+
+        location /api {
+            expires off;
+            proxy_pass http://zipkin:9411;
+        }
+
+        location /config.json {
+            expires 10m;
+            proxy_pass http://zipkin:9411;
+        }
+
+        location /traces {
+            try_files $uri /index.html;
+        }
+
+        location /dependency {
+            try_files $uri /index.html;
+        }
+
+        location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+            expires 1d;
+            add_header Cache-Control "public";
+        }
+
+        location = /favicon.ico { log_not_found off; access_log off; }
+        location = /robots.txt  { access_log off; log_not_found off; }
+
+        # Deny .htaccess file access
+        location ~ /\.ht {
+            deny all;
+        }
+
+    }
+}


### PR DESCRIPTION
This container doubles as a skeleton for creating proxy configuration around
Zipkin like authentication, dealing with CORS with zipkin-js apps, or
terminating SSL.

It can also be adapted to test new UIs, such as https://github.com/openzipkin/zipkin-ui

Related issues which having an example NGINX config could help with:

See https://github.com/openzipkin/zipkin/issues/782
See https://github.com/openzipkin/zipkin/issues/1135
See https://github.com/openzipkin/zipkin/issues/1171
See https://github.com/openzipkin/zipkin/issues/974