### PR TITLE
Use Elasticsearch 5 in test image, switching default transport to http

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When in docker, the following environment variables also apply
 * `STORAGE_PORT_3306_TCP_ADDR` -- A MySQL node listening on port 3306. This
   environment variable is typically set by linking a container running
   `zipkin-mysql` as "storage" when you start the container.
-* `STORAGE_PORT_9300_TCP_ADDR` -- An Elasticsearch node listening on port 9300. This
+* `STORAGE_PORT_9200_TCP_ADDR` -- An Elasticsearch node listening on port 9200. This
   environment variable is typically set by linking a container running
   `zipkin-elasticsearch` as "storage" when you start the container. This is ignored
   when `ES_HOSTS` or `ES_AWS_DOMAIN` are set.
@@ -109,6 +109,18 @@ to swap out one storage container for another.
 To start the Elasticsearch-backed configuration, run:
 
     $ docker-compose -f docker-compose.yml -f docker-compose-elasticsearch.yml up
+
+#### Elasticsearch 5 and Host setup
+
+The `docker-elasticsearch5` image is [more strict](https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup) about virtual memory. You will need to adjust accordingly (especially if you notice elasticsearch crash!)
+
+```bash
+# If docker is running on your host machine, adjust the kernel setting directly
+$ sudo sysctl -w vm.max_map_count=262144
+
+# If using docker-machine/Docker Toolbox/Boot2Docker, remotely adjust the same
+$ docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
+```
 
 #### Elasticsearch Service on Amazon
 

--- a/docker-compose-elasticsearch.yml
+++ b/docker-compose-elasticsearch.yml
@@ -7,15 +7,13 @@
 version: '2'
 
 services:
-  # Run Elasticsearch instead of Cassandra
+  # Run Elasticsearch instead of MySQL
   storage:
     image: openzipkin/zipkin-elasticsearch:1.16.0
     container_name: elasticsearch
     ports:
       # http
       - 9200:9200
-      # transport
-      - 9300:9300
 
   # Switch storage type to Elasticsearch
   zipkin:
@@ -23,7 +21,7 @@ services:
     environment:
       - STORAGE_TYPE=elasticsearch
       # Point the zipkin at the storage backend
-      - ES_HOSTS=elasticsearch
+      - ES_HOSTS=http://elasticsearch:9200
   dependencies:
     environment:
       - STORAGE_TYPE=elasticsearch

--- a/elasticsearch5/Dockerfile
+++ b/elasticsearch5/Dockerfile
@@ -14,7 +14,7 @@
 FROM openzipkin/jre-full:1.8.0_112
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
-ENV ELASTICSEARCH_VERSION 2.3.4
+ENV ELASTICSEARCH_VERSION 5.0.1
 
 WORKDIR /elasticsearch
 
@@ -27,6 +27,9 @@ RUN curl -SL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-
 # elasticsearch complains if run as root
 USER elasticsearch
 
+COPY config ./config
+
 EXPOSE 9200 9300
 
-CMD /elasticsearch/bin/elasticsearch -Des.network.host=0.0.0.0
+# our image doesn't have bash, so use sh instead, also remove JAVA_OPTS in favor of ES_JAVA_OPTS
+CMD JAVA_OPTS= sh /elasticsearch/bin/elasticsearch

--- a/elasticsearch5/config/elasticsearch.yml
+++ b/elasticsearch5/config/elasticsearch.yml
@@ -1,0 +1,2 @@
+network.host: 0.0.0.0
+discovery.zen.minimum_master_nodes: 1

--- a/release.sh
+++ b/release.sh
@@ -32,8 +32,8 @@ started_at=$($date +%s)
 ## Read input and env
 release_tag="$1"
 # Service images
-images="${IMAGES:-zipkin-cassandra zipkin-elasticsearch zipkin-kafka zipkin-ui zipkin-mysql zipkin}"
-dirs="${DIRS:-cassandra elasticsearch kafka zipkin-ui mysql zipkin}"
+images="${IMAGES:-zipkin-cassandra zipkin-elasticsearch zipkin-elasticsearch5 zipkin-kafka zipkin-ui zipkin-mysql zipkin}"
+dirs="${DIRS:-cassandra elasticsearch elasticsearch5 kafka zipkin-ui mysql zipkin}"
 # Remotes, auth
 docker_organization="${DOCKER_ORGANIZATION:-openzipkin}"
 quayio_oauth2_token="$QUAYIO_OAUTH2_TOKEN"

--- a/zipkin/zipkin/.elasticsearch_profile
+++ b/zipkin/zipkin/.elasticsearch_profile
@@ -1,13 +1,13 @@
 #!/bin/sh
 if [[ -z $ES_HOSTS && -z $ES_AWS_DOMAIN ]]; then
-  if [[ -z $STORAGE_PORT_9300_TCP_ADDR ]]; then
+  if [[ -z $STORAGE_PORT_9200_TCP_ADDR ]]; then
     echo "** ERROR: You need to link with a Elasticsearch container as 'storage' or specify an"
     echo "elasticsearch cluster via the ES_HOSTS (hostname:port or http url) or ES_AWS_DOMAIN env vars."
-    echo "STORAGE_PORT_9300_TCP_ADDR (container link) should contain an address, or one of ES_HOSTS or"
+    echo "STORAGE_PORT_9200_TCP_ADDR (container link) should contain an address, or one of ES_HOSTS or"
     echo "ES_AWS_DOMAIN should be set."
     exit 1
   fi
-  ES_HOSTS=$STORAGE_PORT_9300_TCP_ADDR
+  ES_HOSTS=http://$STORAGE_PORT_9200_TCP_ADDR:9200
 fi
 
 export ES_HOSTS


### PR DESCRIPTION
This changes the default Elasticsearch transport to http so that we can
use Elasticsearch 5 as the test image, as well see self-traces.

The test image of Elasticsearch is version 5.x which is [more strict](https://github.com/docker-library/docs/tree/master/elasticsearch#host-setup) about virtual memory. You will need to adjust accordingly (especially if you
notice elasticsearch crash!)

```bash
# If docker is running on your host machine, adjust the kernel setting directly
$ sudo sysctl -w vm.max_map_count=262144

# If using docker-machine/Docker Toolbox/Boot2Docker, remotely adjust the same
$ docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
```
