### PR TITLE
Fix #121: Add example prometheus setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ terminating SSL.
 Zipkin comes with a built-in Prometheus metric exporter. The main
 `docker-compose.yml` file starts Prometheus configured to scrape Zipkin, exposes
 it on port `9090`. You can open `$DOCKER_HOST_IP:9090` and start exploring the
-metrics (which are available on the `/promethes` endpoint of Zipkin).
+metrics (which are available on the `/prometheus` endpoint of Zipkin).
 
 `docker-compose.yml` also starts a Grafana container with authentication
 disabled, exposing it on port 3000. On startup it's configured with the

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ metrics (which are available on the `/promethes` endpoint of Zipkin).
 `docker-compose.yml` also starts a Grafana container with authentication
 disabled, exposing it on port 3000. It has built-in support for Prometheus data
 sources, so you can point it to `$DOCKER_HOST_IP:9090`, and experiment with
-creating dashboards. One immediately useful graph can be showing all the
-`response_*` metrics on one graph to show response times per endpoint.
+creating dashboards. A good starting point would be importing the dashboard
+published at https://grafana.net/dashboards/1598.
 
 Note that dashboards will be lost between restarts of the containers - again,
 this is not a production environment, it's aimed to help the first steps in

--- a/README.md
+++ b/README.md
@@ -190,14 +190,12 @@ it on port `9090`. You can open `$DOCKER_HOST_IP:9090` and start exploring the
 metrics (which are available on the `/promethes` endpoint of Zipkin).
 
 `docker-compose.yml` also starts a Grafana container with authentication
-disabled, exposing it on port 3000. It has built-in support for Prometheus data
-sources, so you can point it to `$DOCKER_HOST_IP:9090`, and experiment with
-creating dashboards. A good starting point would be importing the dashboard
-published at https://grafana.net/dashboards/1598.
-
-Note that dashboards will be lost between restarts of the containers - again,
-this is not a production environment, it's aimed to help the first steps in
-learning Zipkin.
+disabled, exposing it on port 3000. On startup it's configured with the
+Prometheus instance started by `docker-compose` as a data source, and imports
+the dashboard published at https://grafana.net/dashboards/1598. This means that,
+after running `docker-compose up`, you can open
+`$DOCKER_IP:3000/dashboard/db/zipkin-prometheus` and play around with the
+dashboard.
 
 If you want to run the zipkin-ui standalone against a remote zipkin server, you
 need to set `ZIPKIN_BASE_URL` accordingly:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,24 @@ To start the NGINX configuration, run:
 
 This container doubles as a skeleton for creating proxy configuration around
 Zipkin like authentication, dealing with CORS with zipkin-js apps, or
-terminating SSL. 
+terminating SSL.
+
+### Prometheus
+
+Zipkin comes with a built-in Prometheus metric exporter. The main
+`docker-compose.yml` file starts Prometheus configured to scrape Zipkin, exposes
+it on port `9090`. You can open `$DOCKER_HOST_IP:9090` and start exploring the
+metrics (which are available on the `/promethes` endpoint of Zipkin).
+
+`docker-compose.yml` also starts a Grafana container with authentication
+disabled, exposing it on port 3000. It has built-in support for Prometheus data
+sources, so you can point it to `$DOCKER_HOST_IP:9090`, and experiment with
+creating dashboards. One immediately useful graph can be showing all the
+`response_*` metrics on one graph to show response times per endpoint.
+
+Note that dashboards will be lost between restarts of the containers - again,
+this is not a production environment, it's aimed to help the first steps in
+learning Zipkin.
 
 If you want to run the zipkin-ui standalone against a remote zipkin server, you
 need to set `ZIPKIN_BASE_URL` accordingly:

--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ To start the MySQL+Kafka configuration, run:
 
 Then configure the [Kafka 0.10 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java)
 or [Kafka 0.8 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java)
-using a `bootstrapServers` value of `192.168.99.100:9092`. 
+using a `bootstrapServers` value of `192.168.99.100:9092`.
 
 By default, this assumes your Docker host IP is 192.168.99.100. If this is
-not the case, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka10.yml` 
-and the `bootstrapServers` configuration of the kafka sender to match your 
+not the case, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka10.yml`
+and the `bootstrapServers` configuration of the kafka sender to match your
 Docker host IP.
 
-If you prefer to activate the 
+If you prefer to activate the
 [Kafka 0.8 collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka)
 use `docker-compose-kafka.yml` instead of `docker-compose-kafka10.yml`:
 
@@ -192,7 +192,7 @@ metrics (which are available on the `/prometheus` endpoint of Zipkin).
 `docker-compose.yml` also starts a Grafana container with authentication
 disabled, exposing it on port 3000. On startup it's configured with the
 Prometheus instance started by `docker-compose` as a data source, and imports
-the dashboard published at https://grafana.net/dashboards/1598. This means that,
+the dashboard published at https://grafana.com/dashboards/1598. This means that,
 after running `docker-compose up`, you can open
 `$DOCKER_IP:3000/dashboard/db/zipkin-prometheus` and play around with the
 dashboard.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,3 +58,24 @@ services:
       # - JAVA_OPTS=-verbose:gc -Xms1G -Xmx1G
     depends_on:
       - storage
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - 9090:9090
+    depends_on:
+      - storage
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,3 +79,12 @@ services:
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+
+  setup_grafana_datasource:
+    image: appropriate/curl
+    container_name: setup_grafana_datasource
+    depends_on:
+      - grafana
+    volumes:
+      - ./prometheus/create-datasource-and-dashboard.sh:/create.sh:ro
+    command: /create.sh

--- a/prometheus/create-datasource-and-dashboard.sh
+++ b/prometheus/create-datasource-and-dashboard.sh
@@ -9,9 +9,9 @@ if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/
 fi
 
 dashboard_id=1598
-last_revision=$(curl -sf https://grafana.net/api/dashboards/${dashboard_id}/revisions | grep '"revision":' | sed 's/ *"revision": \([0-9]*\),/\1/' | sort -n | tail -1)
+last_revision=$(curl -sf https://grafana.com/api/dashboards/${dashboard_id}/revisions | grep '"revision":' | sed 's/ *"revision": \([0-9]*\),/\1/' | sort -n | tail -1)
 
-curl -s https://grafana.net/api/dashboards/${dashboard_id}/revisions/${last_revision}/download | \
+curl -s https://grafana.com/api/dashboards/${dashboard_id}/revisions/${last_revision}/download | \
     xargs -0 -I "{}" curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
           -X POST -H "Content-Type: application/json" \
           --data-binary '{"dashboard": {}, "inputs": [{"name": "DS_PROM", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' \

--- a/prometheus/create-datasource-and-dashboard.sh
+++ b/prometheus/create-datasource-and-dashboard.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -xeuo pipefail
+
+if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/api/dashboards/name/prom; then
+    curl -sf -X POST -H "Content-Type: application/json" \
+         --data-binary '{"name":"prom","type":"prometheus","url":"http://prometheus:9090","access":"proxy","isDefault":true}' \
+         http://grafana:3000/api/datasources
+fi
+
+curl -s https://grafana.net/api/dashboards/1598/revisions/1/download | \
+    xargs -0 -I "{}" curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
+          -X POST -H "Content-Type: application/json" \
+          --data-binary '{"dashboard": {}, "inputs": [{"name": "DS_PROM", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' \
+          http://grafana:3000/api/dashboards/import

--- a/prometheus/create-datasource-and-dashboard.sh
+++ b/prometheus/create-datasource-and-dashboard.sh
@@ -11,8 +11,10 @@ fi
 dashboard_id=1598
 last_revision=$(curl -sf https://grafana.com/api/dashboards/${dashboard_id}/revisions | grep '"revision":' | sed 's/ *"revision": \([0-9]*\),/\1/' | sort -n | tail -1)
 
-curl -s https://grafana.com/api/dashboards/${dashboard_id}/revisions/${last_revision}/download | \
-    xargs -0 -I "{}" curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
-          -X POST -H "Content-Type: application/json" \
-          --data-binary '{"dashboard": {}, "inputs": [{"name": "DS_PROM", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' \
-          http://grafana:3000/api/dashboards/import
+echo '{"dashboard": ' > data.json
+curl -s https://grafana.com/api/dashboards/${dashboard_id}/revisions/${last_revision}/download >> data.json
+echo ', "inputs": [{"name": "DS_PROM", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' >> data.json
+curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
+     -X POST -H "Content-Type: application/json" \
+     --data-binary @data.json \
+     http://grafana:3000/api/dashboards/import

--- a/prometheus/create-datasource-and-dashboard.sh
+++ b/prometheus/create-datasource-and-dashboard.sh
@@ -8,7 +8,10 @@ if ! curl --retry 5 --retry-connrefused --retry-delay 0 -sf http://grafana:3000/
          http://grafana:3000/api/datasources
 fi
 
-curl -s https://grafana.net/api/dashboards/1598/revisions/1/download | \
+dashboard_id=1598
+last_revision=$(curl -sf https://grafana.net/api/dashboards/${dashboard_id}/revisions | grep '"revision":' | sed 's/ *"revision": \([0-9]*\),/\1/' | sort -n | tail -1)
+
+curl -s https://grafana.net/api/dashboards/${dashboard_id}/revisions/${last_revision}/download | \
     xargs -0 -I "{}" curl --retry-connrefused --retry 5 --retry-delay 0 -sf \
           -X POST -H "Content-Type: application/json" \
           --data-binary '{"dashboard": {}, "inputs": [{"name": "DS_PROM", "pluginId": "prometheus", "type": "datasource", "value": "prom"}], "overwrite": false}' \

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'zipkin'
+    scrape_interval: 5s
+    metrics_path: '/prometheus'
+    static_configs:
+      - targets: ['zipkin:9411']

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -14,32 +14,23 @@ scrape_configs:
     metric_relabel_configs:
       # Response code count
       - source_labels: [__name__]
-        regex: '^status_(\d+)_(.*)$'
+        regex: '^counter_status_(\d+)_(.*)$'
         replacement: '${1}'
         target_label: status
       - source_labels: [__name__]
-        regex: '^status_(\d+)_(.*)$'
+        regex: '^counter_status_(\d+)_(.*)$'
         replacement: '${2}'
         target_label: path
       - source_labels: [__name__]
-        regex: '^status_(\d+)_(.*)$'
+        regex: '^counter_status_(\d+)_(.*)$'
         replacement: 'http_requests_total'
-        target_label: __name__
-      # Response time, pending histogram from https://github.com/openzipkin/zipkin/pull/1609
-      - source_labels: [__name__]
-        regex: '^response_(.*)$'
-        replacement: '${1}'
-        target_label: path
-      - source_labels: [__name__]
-        regex: '^response_(.*)$'
-        replacement: 'http_request_duration_milliseconds'
         target_label: __name__
       # Received message count
       - source_labels: [__name__]
-        regex: 'zipkin_collector_(.*)_([^_]*)'
+        regex: '(?:gauge|counter)_zipkin_collector_(.*)_([^_]*)'
         replacement: '${2}'
         target_label: transport
       - source_labels: [__name__]
-        regex: 'zipkin_collector_(.*)_([^_]*)'
+        regex: '(?:gauge|counter)_zipkin_collector_(.*)_([^_]*)'
         replacement: 'zipkin_collector_${1}'
         target_label: __name__

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -23,7 +23,7 @@ scrape_configs:
         target_label: path
       - source_labels: [__name__]
         regex: '^status_(\d+)_(.*)$'
-        replacement: 'http_requests_count'
+        replacement: 'http_requests_total'
         target_label: __name__
       # Response time, pending histogram from https://github.com/openzipkin/zipkin/pull/1609
       - source_labels: [__name__]

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,3 +11,26 @@ scrape_configs:
     metrics_path: '/prometheus'
     static_configs:
       - targets: ['zipkin:9411']
+    metric_relabel_configs:
+      # Response code count
+      - source_labels: [__name__]
+        regex: '^status_(\d+)_(.*)$'
+        replacement: '${1}'
+        target_label: status
+      - source_labels: [__name__]
+        regex: '^status_(\d+)_(.*)$'
+        replacement: '${2}'
+        target_label: path
+      - source_labels: [__name__]
+        regex: '^status_(\d+)_(.*)$'
+        replacement: 'http_requests_count'
+        target_label: __name__
+      # Response time, pending histogram from https://github.com/openzipkin/zipkin/pull/1609
+      - source_labels: [__name__]
+        regex: '^response_(.*)$'
+        replacement: '${1}'
+        target_label: path
+      - source_labels: [__name__]
+        regex: '^response_(.*)$'
+        replacement: 'http_request_duration_milliseconds'
+        target_label: __name__

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -34,3 +34,12 @@ scrape_configs:
         regex: '^response_(.*)$'
         replacement: 'http_request_duration_milliseconds'
         target_label: __name__
+      # Received message count
+      - source_labels: [__name__]
+        regex: 'zipkin_collector_(.*)_([^_]*)'
+        replacement: '${2}'
+        target_label: transport
+      - source_labels: [__name__]
+        regex: 'zipkin_collector_(.*)_([^_]*)'
+        replacement: 'zipkin_collector_${1}'
+        target_label: __name__


### PR DESCRIPTION
Add Prometheus, Grafana to `docker-compose.yml`. Document basic usage and setup. See #121 for reasoning.

I attempted to "ship" with a state where Grafana is already configured, but it's not completely trivial (where do you store the initial state? How do you get it to Grafana) leading to complexity. It would also remove some of the learning we expect to provide - automating it here means users will need to re-discover it later.