### PR TITLE
Allow configuring ZIPKIN_BASE_URL for zipkin-ui image

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ This container doubles as a skeleton for creating proxy configuration around
 Zipkin like authentication, dealing with CORS with zipkin-js apps, or
 terminating SSL. 
 
+If you want to run the zipkin-ui standalone against a remote zipkin server, you
+need to set `ZIPKIN_BASE_URL` accordingly:
+
+```bash
+$ docker run -d -p 80:80 \
+  -e ZIPKIN_BASE_URL=http://myfavoritezipkin:9411 \
+  openzipkin/zipkin-ui
+```
+
 ### Legacy
 
 The docker-compose files described above use version 2 of the docker-compose

--- a/docker-compose-ui.yml
+++ b/docker-compose-ui.yml
@@ -10,6 +10,9 @@ services:
   zipkin-ui:
     image: openzipkin/zipkin-ui
     container_name: zipkin-ui
+    environment:
+      # Change this if connecting to a different zipkin server
+      - ZIPKIN_BASE_URL=http://zipkin:9411
     ports:
       - 80:80
     depends_on:

--- a/zipkin-ui/Dockerfile
+++ b/zipkin-ui/Dockerfile
@@ -1,7 +1,8 @@
 FROM nginx:alpine
 
 ENV ZIPKIN_REPO https://jcenter.bintray.com
-ENV ZIPKIN_UI_VERSION 0.0.1
+ENV ZIPKIN_UI_VERSION 0.2.1
+ENV ZIPKIN_BASE_URL=http://zipkin:9411
 
 RUN apk add --update --no-cache nginx curl && \
     rm -rf /var/cache/apk/* /tmp/* /var/tmp/* && \
@@ -12,8 +13,9 @@ RUN apk add --update --no-cache nginx curl && \
     rm -rf zipkin-ui zipkin-ui.jar
 
 # Setup services
-ADD nginx.conf /etc/nginx/nginx.conf
+ADD nginx.conf /etc/nginx/conf.d/zipkin.conf.template
+ADD run.sh /usr/local/bin/nginx.sh
 
 EXPOSE 80
 
-CMD ["nginx"]
+CMD /usr/local/bin/nginx.sh

--- a/zipkin-ui/nginx.conf
+++ b/zipkin-ui/nginx.conf
@@ -48,20 +48,7 @@ http {
 
         location /api {
             expires off;
-            proxy_pass http://zipkin:9411;
-        }
-
-        location /config.json {
-            expires 10m;
-            proxy_pass http://zipkin:9411;
-        }
-
-        location /traces {
-            try_files $uri /index.html;
-        }
-
-        location /dependency {
-            try_files $uri /index.html;
+            proxy_pass ${ZIPKIN_BASE_URL};
         }
 
         location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {

--- a/zipkin-ui/run.sh
+++ b/zipkin-ui/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+envsubst '\$ZIPKIN_BASE_URL' < /etc/nginx/conf.d/zipkin.conf.template > /etc/nginx/nginx.conf
+nginx


### PR DESCRIPTION
This changes the zipkin-ui image to rewrite nginx configuration on start
based on the `ZIPKIN_BASE_URL` variable, which defaults to
'http://zipkin:9411'. Users can change this variable to point at a
different zipkin host such as a kubernetes pod.

See https://github.com/openzipkin/zipkin-ui/pull/38
Fixes #134