### PR TITLE
Updated docs with how to run the kafka10 collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,29 @@ $ docker run -d -p 9411:9411 \
 ### Kafka
 
 The docker-compose configuration can be extended to host a test Kafka broker
-using the `docker-compose-kafka.yml` file. That file employs
+and activate the [Kafka 0.10 collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka10)
+using the `docker-compose-kafka10.yml` file. That file employs
 [docker-compose overrides](https://docs.docker.com/compose/extends/#multiple-compose-files)
 to add a Kafka+ZooKeeper container and relevant settings.
 
 To start the MySQL+Kafka configuration, run:
 
-    $ docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up
+    $ docker-compose -f docker-compose.yml -f docker-compose-kafka10.yml up
 
-By default, this assumes your Docker host IP is 192.168.99.100, which is what
-you would use for the broker IP when configuring application instrumentation.
+Then configure the [Kafka 0.10 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java)
+or [Kafka 0.8 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java)
+using a `bootstrapServers` value of `192.168.99.100:9092`. 
+
+By default, this assumes your Docker host IP is 192.168.99.100. If this is
+not the case, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka10.yml` 
+and the `bootstrapServers` configuration of the kafka sender to match your 
+Docker host IP.
+
+If you prefer to activate the 
+[Kafka 0.8 collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka)
+use `docker-compose-kafka.yml` instead of `docker-compose-kafka10.yml`:
+
+    $ docker-compose -f docker-compose.yml -f docker-compose-kafka.yml up
 
 ### UI
 


### PR DESCRIPTION
Updated documentation to use the kafka10 docker-compose configuration as the primary example for testing with Kafka. Also added example of switching to docker-compose-kafka.yml in order to use the kafka 0.8 collector.