### PR TITLE
Correct the fact that Scribe is disabled by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     #   - 3306:3306
 
   # The zipkin process services the UI, and also exposes a POST endpoint that
-  # instrumentation can send trace data to. Scribe is enabled by default.
+  # instrumentation can send trace data to. Scribe is disabled by default.
   zipkin:
     image: openzipkin/zipkin
     container_name: zipkin


### PR DESCRIPTION
It seems that Scribe is disabled by default:

```yml
    # Uncomment to enable scribe
    # - SCRIBE_ENABLED=true
...
    # Uncomment if you set SCRIBE_ENABLED=true
    # - 9410:9410
```

But a line in docker-compose.yml states that it was enabled by default. I just corrected it to state that Scribe was disabled by default