### PR TITLE
Propagate SIGTERM to Java in Dockerfiles

### DIFF
--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -17,6 +17,6 @@ RUN /usr/local/bin/install
 USER cassandra
 
 ADD run.sh /usr/local/bin/run.sh
-CMD /usr/local/bin/run.sh
+CMD ["/usr/local/bin/run.sh"]
 
 EXPOSE 9160 7000 7001 9042 7199

--- a/cassandra/run.sh
+++ b/cassandra/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/cassandra/bin/cassandra -f
+exec /cassandra/bin/cassandra -f

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -29,4 +29,4 @@ USER elasticsearch
 
 EXPOSE 9200 9300
 
-CMD /elasticsearch/bin/elasticsearch -Des.network.host=0.0.0.0
+CMD ["/elasticsearch/bin/elasticsearch", "-Des.network.host=0.0.0.0"]

--- a/elasticsearch5/Dockerfile
+++ b/elasticsearch5/Dockerfile
@@ -32,4 +32,4 @@ COPY config ./config
 EXPOSE 9200 9300
 
 # our image doesn't have bash, so use sh instead, also remove JAVA_OPTS in favor of ES_JAVA_OPTS
-CMD JAVA_OPTS= sh /elasticsearch/bin/elasticsearch
+CMD JAVA_OPTS= exec sh /elasticsearch/bin/elasticsearch

--- a/elasticsearch6/Dockerfile
+++ b/elasticsearch6/Dockerfile
@@ -32,4 +32,4 @@ COPY config ./config
 EXPOSE 9200 9300
 
 # our image doesn't have bash, so use sh instead, also remove JAVA_OPTS in favor of ES_JAVA_OPTS
-CMD JAVA_OPTS= sh /elasticsearch/bin/elasticsearch
+CMD JAVA_OPTS= exec sh /elasticsearch/bin/elasticsearch

--- a/zipkin-ui/Dockerfile
+++ b/zipkin-ui/Dockerfile
@@ -19,4 +19,4 @@ ADD run.sh /usr/local/bin/nginx.sh
 
 EXPOSE 80
 
-CMD /usr/local/bin/nginx.sh
+CMD ["/usr/local/bin/nginx.sh"]

--- a/zipkin-ui/run.sh
+++ b/zipkin-ui/run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 envsubst '\$ZIPKIN_BASE_URL' < /etc/nginx/conf.d/zipkin.conf.template > /etc/nginx/nginx.conf
-nginx
+exec nginx

--- a/zipkin/Dockerfile
+++ b/zipkin/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE 9410 9411
 
 CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; \
     test -n "$KAFKA_BOOTSTRAP_SERVERS" && JAVA_OPTS="${JAVA_OPTS} -Dloader.path=kafka10 -Dspring.profiles.active=kafka"; \
-    java ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
+    exec java ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher


### PR DESCRIPTION
Allow Zipkin to quickly stop in docker-compose by propagating signals to Java.
The signal was sent to bash and ignored.
