### PR TITLE
Fixes crash in elasticsearch6 image for various reasons

### DIFF
--- a/elasticsearch6/Dockerfile
+++ b/elasticsearch6/Dockerfile
@@ -15,12 +15,16 @@ FROM openzipkin/jre-full:1.8.0_171
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 ENV ELASTICSEARCH_VERSION 6.3.0
+# https://github.com/elastic/elasticsearch/pull/31003 was closed won't fix
+ENV ES_TMPDIR /tmp
 
 WORKDIR /elasticsearch
 
 # single layer to install elasticsearch and the user
 RUN curl -SL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz| tar xz && \
     mv elasticsearch-$ELASTICSEARCH_VERSION/* /elasticsearch/ && \
+    # disable ML as not supported on alpine per https://discuss.elastic.co/t/elasticsearch-failing-to-start-due-to-x-pack/85125/6
+    rm -rf /elasticsearch/modules/x-pack/x-pack-ml/platform/linux-x86_64 && \
     adduser -S elasticsearch && \
     chown -R elasticsearch /elasticsearch
 

--- a/elasticsearch6/config/elasticsearch.yml
+++ b/elasticsearch6/config/elasticsearch.yml
@@ -1,2 +1,3 @@
 network.host: 0.0.0.0
 discovery.zen.minimum_master_nodes: 1
+xpack.ml.enabled: false


### PR DESCRIPTION
@michael1589 reported our test elasticsearch6 image was broken. This happened due to 2 known issues

Adding workarounds from the following:
https://github.com/elastic/elasticsearch/pull/31003
https://discuss.elastic.co/t/elasticsearch-failing-to-start-due-to-x-pack/85125/6