### PR TITLE
Upgrades Kafka to 2.0 and listens on localhost:19092

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,12 +159,10 @@ To start the MySQL+Kafka configuration, run:
 
 Then configure the [Kafka sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java)
 or [Kafka 0.8 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/master/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java)
-using a `bootstrapServers` value of `192.168.99.100:9092`.
+using a `bootstrapServers` value of `host.docker.internal:9092` if your application is a docker container or `localhost:19092` if not, but running on the same host.
 
-By default, this assumes your Docker host IP is 192.168.99.100. If this is
-not the case, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka.yml`
-and the `bootstrapServers` configuration of the kafka sender to match your
-Docker host IP.
+If you are using Docker machine, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka.yml`
+and the `bootstrapServers` configuration of the kafka sender to match your Docker host IP (ex. 192.168.99.100:9092).
 
 If you prefer to activate the
 [Kafka 0.8 collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka08) (which uses ZooKeeper),

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ or [Kafka 0.8 sender](https://github.com/openzipkin/zipkin-reporter-java/blob/ma
 using a `bootstrapServers` value of `host.docker.internal:9092` if your application is a docker container or `localhost:19092` if not, but running on the same host.
 
 If you are using Docker machine, adjust `KAFKA_ADVERTISED_HOST_NAME` in `docker-compose-kafka.yml`
-and the `bootstrapServers` configuration of the kafka sender to match your Docker host IP (ex. 192.168.99.100:9092).
+and the `bootstrapServers` configuration of the kafka sender to match your Docker host IP (ex. 192.168.99.100:19092).
 
 If you prefer to activate the
 [Kafka 0.8 collector](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka08) (which uses ZooKeeper),

--- a/docker-compose-kafka.yml
+++ b/docker-compose-kafka.yml
@@ -10,12 +10,16 @@ services:
   kafka-zookeeper:
     image: openzipkin/zipkin-kafka
     container_name: kafka-zookeeper
-    environment:
-      # corresponds to your docker machine and your producer's broker list
-      - KAFKA_ADVERTISED_HOST_NAME=192.168.99.100
+    # If using docker machine, uncomment the below and set your bootstrap
+    # server list to 192.168.99.100:19092
+    # environment:
+      # - KAFKA_ADVERTISED_HOST_NAME=192.168.99.100
     ports:
       - 2181:2181
       - 9092:9092
+      # port 19092 is listening on localhost by default. In normal Docker,
+      # you can set your bootstrap server list to localhost:19092
+      - 19092:19092
 
   zipkin:
     environment:

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -3,13 +3,14 @@ FROM openzipkin/jre-full:1.8.0_171
 MAINTAINER OpenZipkin "http://zipkin.io/"
 
 ENV SCALA_VERSION 2.12
-ENV KAFKA_VERSION 1.1.0
-ENV ZOOKEEPER_VERSION 3.4.10
+ENV KAFKA_VERSION 2.0.0
+ENV ZOOKEEPER_VERSION 3.4.13
 
 WORKDIR /kafka
 ADD install.sh /kafka/install
 RUN /kafka/install
 
-EXPOSE 2181 9092
+# Port 19092 is for connections from the Docker host
+EXPOSE 2181 9092 19092
 
 CMD ["runsvdir", "/etc/service"]

--- a/kafka/install.sh
+++ b/kafka/install.sh
@@ -32,7 +32,8 @@ replica.socket.timeout.ms=1500
 log.dirs=/kafka/logs
 auto.create.topics.enable=true
 offsets.topic.replication.factor=1
-listeners=PLAINTEXT://:9092
+listeners=PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:19092
+listener.security.protocol.map=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
 EOF
 
 # create runit config, dependent on zookeeper, that advertises the container ip
@@ -41,9 +42,10 @@ cat > /etc/service/kafka/run <<-"EOF"
 #!/bin/sh
 sv start zookeeper || exit 1
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-  echo advertised.listeners=PLAINTEXT://$(route -n | awk '/UG[ \t]/{print $2}'):9092 >> /kafka/config/server.properties
+listeners=PLAINTEXT://:9092
+  echo advertised.listeners=PLAINTEXT://$(route -n | awk '/UG[ \t]/{print $2}'):9092,PLAINTEXT_HOST://localhost:19092 >> /kafka/config/server.properties
 else
-  echo "advertised.listeners=PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092" >> /kafka/config/server.properties
+  echo "advertised.listeners=PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,PLAINTEXT_HOST://localhost:19092" >> /kafka/config/server.properties
 fi
 exec sh /kafka/bin/kafka-run-class.sh -name kafkaServer -loggc kafka.Kafka /kafka/config/server.properties
 EOF

--- a/kafka/install.sh
+++ b/kafka/install.sh
@@ -43,9 +43,11 @@ cat > /etc/service/kafka/run <<-"EOF"
 sv start zookeeper || exit 1
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
 listeners=PLAINTEXT://:9092
-  echo advertised.listeners=PLAINTEXT://$(route -n | awk '/UG[ \t]/{print $2}'):9092,PLAINTEXT_HOST://localhost:19092 >> /kafka/config/server.properties
+  # Have internal docker producers and consumers use the normal hostname:9092, and outside docker localhost:19092
+  echo advertised.listeners=PLAINTEXT://${HOSTNAME}:9092,PLAINTEXT_HOST://localhost:19092 >> /kafka/config/server.properties
 else
-  echo "advertised.listeners=PLAINTEXT://${KAFKA_ADVERTISED_HOST_NAME}:9092,PLAINTEXT_HOST://localhost:19092" >> /kafka/config/server.properties
+  # Have internal docker producers and consumers use the normal hostname:9092, and outside docker the advertised host on port 19092
+  echo "advertised.listeners=PLAINTEXT://${HOSTNAME}:9092,PLAINTEXT_HOST://${KAFKA_ADVERTISED_HOST_NAME}:19092" >> /kafka/config/server.properties
 fi
 exec sh /kafka/bin/kafka-run-class.sh -name kafkaServer -loggc kafka.Kafka /kafka/config/server.properties
 EOF


### PR DESCRIPTION
This follows advice from @jeqo and makes Kafka listen on another port
for non-docker apps. For example, if running a demo not in docker, you
can set its broker list to localhost:19092

Closes #186