### PR TITLE
fix(elasticsearch6): remove ml module

### DIFF
--- a/elasticsearch6/Dockerfile
+++ b/elasticsearch6/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /elasticsearch
 RUN curl -SL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTICSEARCH_VERSION.tar.gz| tar xz && \
     mv elasticsearch-$ELASTICSEARCH_VERSION/* /elasticsearch/ && \
     # disable ML as not supported on alpine per https://discuss.elastic.co/t/elasticsearch-failing-to-start-due-to-x-pack/85125/6
-    rm -rf /elasticsearch/modules/x-pack/x-pack-ml/platform/linux-x86_64 && \
+    rm -rf /elasticsearch/modules/x-pack-ml/platform/linux-x86_64 && \
     adduser -S elasticsearch && \
     chown -R elasticsearch /elasticsearch
 


### PR DESCRIPTION
This seems to be the proper path of the ml module to be removed. The original one throws exception:
```
[2018-11-27T14:03:04,025][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: org.elasticsearch.bootstrap.BootstrapException: java.io.IOException: Cannot run program "/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller": error=2, No such file or directory
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:140) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:127) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124) ~[elasticsearch-cli-6.4.2.jar:6.4.2]
        at org.elasticsearch.cli.Command.main(Command.java:90) ~[elasticsearch-cli-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:93) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:86) ~[elasticsearch-6.4.2.jar:6.4.2]
Caused by: org.elasticsearch.bootstrap.BootstrapException: java.io.IOException: Cannot run program "/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller": error=2, No such file or directory
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:168) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:326) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:136) ~[elasticsearch-6.4.2.jar:6.4.2]
        ... 6 more
Caused by: java.io.IOException: Cannot run program "/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller": error=2, No such file or directory
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048) ~[?:1.8.0_171]
        at org.elasticsearch.bootstrap.Spawner.spawnNativeController(Spawner.java:118) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Spawner.spawnNativeControllers(Spawner.java:86) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:166) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:326) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:136) ~[elasticsearch-6.4.2.jar:6.4.2]
        ... 6 more
Caused by: java.io.IOException: error=2, No such file or directory
        at java.lang.UNIXProcess.forkAndExec(Native Method) ~[?:1.8.0_171]
        at java.lang.UNIXProcess.<init>(UNIXProcess.java:247) ~[?:1.8.0_171]
        at java.lang.ProcessImpl.start(ProcessImpl.java:134) ~[?:1.8.0_171]
        at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029) ~[?:1.8.0_171]
        at org.elasticsearch.bootstrap.Spawner.spawnNativeController(Spawner.java:118) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Spawner.spawnNativeControllers(Spawner.java:86) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Bootstrap.setup(Bootstrap.java:166) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:326) ~[elasticsearch-6.4.2.jar:6.4.2]
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:136) ~[elasticsearch-6.4.2.jar:6.4.2]
        ... 6 more
```



I think this version bump https://github.com/openzipkin/docker-zipkin/commit/10cb1c6cfa6ef6217801d743ac75f9041e9aa991 is the root