### PR TITLE
Change the order of ports in the EXPOSE directive

### DIFF
--- a/zipkin/Dockerfile
+++ b/zipkin/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add unzip --no-cache && \
     rm kafka08.jar && \
     apk del unzip
 
-EXPOSE 9410 9411
+EXPOSE 9411 9410
 
 CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; \
     test -n "$SCRIBE_ENABLED" && JAVA_OPTS="${JAVA_OPTS} -Dloader.path=scribe -Dspring.profiles.active=scribe"; \


### PR DESCRIPTION
so that Cloud Foundry user can successfully push a Zipkin with the Docker image.

Cloud Foundry supports docker image but there is a restriction on the port configuration.
Only one exposed port on the image is supported and first one is picked up for the app to listen on.
https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html#port_config

Since 9410 is configured first now, the health check fails.

```
# cf push zipkin --random-route --docker-image openzipkin/zipkin -m 512m

   2019-02-15T12:01:13.98+0900 [APP/PROC/WEB/0] OUT 2019-02-15 03:01:13.979  INFO 29 --- [           main] o.j.threads                              : JBoss Threads version 2.3.2.Final
   2019-02-15T12:01:14.08+0900 [APP/PROC/WEB/0] OUT 2019-02-15 03:01:14.079  INFO 29 --- [           main] o.s.b.w.e.u.UndertowServletWebServer     : Undertow started on port(s) 9411 (http) with context path ''
   2019-02-15T12:01:14.08+0900 [APP/PROC/WEB/0] OUT 2019-02-15 03:01:14.083  INFO 29 --- [           main] z.s.ZipkinServer                         : Started ZipkinServer in 5.958 seconds (JVM running for 7.518)
   2019-02-15T12:02:06.99+0900 [HEALTH/0] ERR Failed to make TCP connection to port 9410: connection refused
   2019-02-15T12:02:06.99+0900 [CELL/0] ERR Timed out after 1m0s: health check never passed.
```