### PR TITLE
Adds MODULE_OPTS to avoid clobbering 3rd party profile config

### DIFF
--- a/zipkin/Dockerfile
+++ b/zipkin/Dockerfile
@@ -41,6 +41,8 @@ ENV ZIPKIN_VERSION 2.12.6
 
 # Use to set heap, trust store or other system properties.
 ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
+# 3rd party modules like zipkin-aws will apply profile settings with this
+ENV MODULE_OPTS=
 
 # Add environment settings for supported storage types
 COPY --from=0 /zipkin/ /zipkin/

--- a/zipkin/zipkin/run.sh
+++ b/zipkin/zipkin/run.sh
@@ -12,4 +12,4 @@ if [ -n "$KAFKA_ZOOKEEPER" ]; then
   export JAVA_OPTS="${JAVA_OPTS} -Dloader.path=kafka08 -Dspring.profiles.active=kafka08"
 fi
 
-exec java ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
+exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher


### PR DESCRIPTION
When we switched to JRE 11, we also switched to distroless. There is a
regression where if you set JAVA_OPTS, it undoes any profile setup for
3rd party modules like zipkin-aws. This could be perceived as messages
from SQS not being processed because sqs wasn't loaded.

Instead, this creates a separate env MODULE_OPTS to hold the layered
config. I tested this on zipkin-aws.