### PR TITLE
Symlink busybox into bin.

### DIFF
--- a/zipkin/Dockerfile
+++ b/zipkin/Dockerfile
@@ -46,6 +46,8 @@ ENV MODULE_OPTS=
 COPY --from=0 /zipkin/ /zipkin/
 WORKDIR /zipkin
 
+RUN ["/busybox/sh", "-c", "ln -s /busybox/* /bin"]
+
 EXPOSE 9410 9411
 
 ENTRYPOINT ["/busybox/sh", "run.sh"]


### PR DESCRIPTION
While zipkin has no scripts that directly reference `/bin/sh`, some users with their own `Dockerfile` might want to add them. While we could put the onus of symlinking these to the users as they should be using a `Dockerfile` for their customization, it's small enough that it seems reasonable to do it in our image.

Fixes #206 