### PR TITLE
sets homedir for each non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ utilities installed, but you can browse contents with a shell like below:
 $ docker run -it --rm --entrypoint /busybox/sh openzipkin/zipkin
 /zipkin $ ls
 BOOT-INF  META-INF  org       run.sh
-``
+```
 
 ## docker-compose
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ For example, to add debug logging, set JAVA_OPTS as shown in our [docker-compose
       - JAVA_OPTS=-Dlogging.level.zipkin=DEBUG -Dlogging.level.zipkin2=DEBUG
 ```
 
+## Runtime user
+The openzipkin/zipkin image runs under a nologin user named 'zipkin' with a home
+directory of '/zipkin'. As this is a distroless image, you won't find many
+utilities installed, but you can browse contents with a shell like below:
+
+```bash
+$ docker run -it --rm --entrypoint /busybox/sh openzipkin/zipkin
+/zipkin $ ls
+BOOT-INF  META-INF  org       run.sh
+``
+
 ## docker-compose
 
 This project is configured to run docker containers using

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -17,7 +17,7 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 ENV JVM_OPTS="-Dcassandra -Dcassandra.config.loader=ZipkinConfigurationLoader -Djava.net.preferIPv4Stack=true"
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D cassandra"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /cassandra -D cassandra"]
 
 COPY --from=0 --chown=cassandra /cassandra /cassandra
 

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -sSL https://download.elasticsearch.org/elasticsearch/release/org/elast
 FROM gcr.io/distroless/java:11-debug
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D elasticsearch"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /elasticsearch -D elasticsearch"]
 
 COPY --from=0 --chown=elasticsearch /elasticsearch /elasticsearch
 

--- a/elasticsearch5/Dockerfile
+++ b/elasticsearch5/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -sSL https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch
 FROM gcr.io/distroless/java:11-debug
 LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D elasticsearch"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /elasticsearch -D elasticsearch"]
 
 COPY --from=0 --chown=elasticsearch /elasticsearch /elasticsearch
 

--- a/elasticsearch6/Dockerfile
+++ b/elasticsearch6/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine
 
-ENV ELASTICSEARCH_VERSION 6.8.1
+ENV ELASTICSEARCH_VERSION 6.8.2
 
 RUN apk add --update curl
 
@@ -29,7 +29,7 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 # https://github.com/elastic/elasticsearch/pull/31003 was closed won't fix
 ENV ES_TMPDIR /tmp
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D elasticsearch"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /elasticsearch -D elasticsearch"]
 
 COPY --from=0 --chown=elasticsearch /elasticsearch /elasticsearch
 

--- a/elasticsearch7/Dockerfile
+++ b/elasticsearch7/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine
 
-ENV ELASTICSEARCH_VERSION 7.2.0
+ENV ELASTICSEARCH_VERSION 7.3.0
 
 RUN apk add --update curl
 
@@ -31,7 +31,7 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 # https://github.com/elastic/elasticsearch/pull/31003 was closed won't fix
 ENV ES_TMPDIR /tmp
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D elasticsearch"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /elasticsearch -D elasticsearch"]
 
 COPY --from=0 --chown=elasticsearch /elasticsearch /elasticsearch
 

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -17,7 +17,7 @@ LABEL MAINTAINER Zipkin "https://zipkin.io/"
 
 WORKDIR /kafka
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D kafka"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /kafka -D kafka"]
 
 COPY --from=0 --chown=kafka /kafka /kafka
 

--- a/zipkin/Dockerfile
+++ b/zipkin/Dockerfile
@@ -36,10 +36,10 @@ ENV JAVA_OPTS -Djava.security.egd=file:/dev/./urandom
 # 3rd party modules like zipkin-aws will apply profile settings with this
 ENV MODULE_OPTS=
 
-RUN ["/busybox/sh", "-c", "adduser -g '' -D zipkin"]
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /zipkin -D zipkin"]
 
 # Add environment settings for supported storage types
-COPY --from=0 /zipkin/ /zipkin/
+COPY --from=0 --chown=zipkin /zipkin/ /zipkin/
 WORKDIR /zipkin
 
 RUN ["/busybox/sh", "-c", "ln -s /busybox/* /bin"]


### PR DESCRIPTION
this reduces confusion. For example, the zipkin-aws missed reading profile config due to the mildy unintuitive difference between /home/zipkin and /zipkin where everything is.