### PR TITLE
Adds AWS Elasticsearch Service image so that it is easier to troubleshoot

### DIFF
--- a/docker-compose-elasticsearch-aws.yml
+++ b/docker-compose-elasticsearch-aws.yml
@@ -1,0 +1,30 @@
+# This runs zipkin against an Amazon Elasticsearch Service
+#
+# Note that this file is meant for learning Zipkin, not production deployments.
+
+version: '2'
+
+services:
+  zipkin:
+    image: openzipkin/zipkin-aws
+    container_name: zipkin
+    environment:
+      - STORAGE_TYPE=elasticsearch
+      # This is an alternative to ES_HOSTS=https://search-zipkin-2rlyh66ibw43ftlk4342ceeewu.ap-southeast-1.es.amazonaws.com
+      - ES_AWS_DOMAIN=zipkin
+      # When ES backs up it doesn't always error, sometimes it will timeout
+      - ES_TIMEOUT=20000
+      # - ES_HTTP_LOGGING=HEADERS
+    volumes:
+      # Share your credentials with your docker image so it can access your Elasticsearch domain
+      - ~/.aws:/zipkin/.aws:ro
+    ports:
+      # Port used for the Zipkin UI and HTTP Api
+      - 9411:9411
+
+  # disable storage as we're using the cloud!
+  storage:
+    image: hello-world
+    container_name: storage-disabled
+    logging:
+      driver: none


### PR DESCRIPTION
Note: a small instance will fall over after about 30 seconds of load :)

Though a small instance seems to stay alive against brave-webmvc-example

```
wrk -t4 -c64 -d20s http://localhost:8081 --latency
```

When ES fails it doesn't fail nicely. Often results in the following
errors instead of an http response:

These warnings will fill logs at the rate of traffic, so I've asked
Armeria what we should do about it.
```
zipkin                      | 2019-08-17 10:35:32.840  WARN 1 --- [orker-epoll-2-4] c.l.a.c.HttpResponseDecoder              : Unexpected exception:
zipkin                      |
zipkin                      | com.linecorp.armeria.client.ResponseTimeoutException: null
```

Also, there seems to be a glitch somewhere, as when I turn on throttling
in attempts to mitigate the above, it seems to amplify failures somehow,
like more drop counts than actual spans. https://github.com/openzipkin/zipkin/issues/2755

Anyway, I think this isn't worse than before, but there's still a good
bit of work to make it easy to use Elasticsearch even when it is anemic.

cc @anuraaga @devinsba @llinder @jcarres-mdsol @Logic-32