### PR TITLE
Allow command line arguments on the image

### DIFF
--- a/zipkin/zipkin/run.sh
+++ b/zipkin/zipkin/run.sh
@@ -4,4 +4,4 @@ if [ -f ".${STORAGE_TYPE}_profile" ]; then
   source ${PWD}/.${STORAGE_TYPE}_profile
 fi
 
-exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
+exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher "$@"


### PR DESCRIPTION
This supports setting the number of spans ala `--max-spans=N` when launching the docker container

Reported in gitter by @ostera