### PR TITLE
Switches to launch with main class vs PropertiesLauncher when possible

### DIFF
--- a/zipkin/zipkin/run.sh
+++ b/zipkin/zipkin/run.sh
@@ -4,4 +4,10 @@ if [ -f ".${STORAGE_TYPE}_profile" ]; then
   source ${PWD}/.${STORAGE_TYPE}_profile
 fi
 
-exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
+# Use main class directly if there are no modules, as it measured 14% faster from JVM running to available
+# verses PropertiesLauncher when using Zipkin was based on Spring Boot 2.1
+if [[ -z "$MODULE_OPTS" ]]; then
+  exec java ${JAVA_OPTS} -cp .:$(ls BOOT-INF/lib/*.jar|tr '\n' ':')BOOT-INF/classes zipkin.server.ZipkinServer
+else
+  exec java ${MODULE_OPTS} ${JAVA_OPTS} -cp . org.springframework.boot.loader.PropertiesLauncher
+fi


### PR DESCRIPTION
After researching before and after startup times with Spring Boot 2.1
vs 2.2, the largest win for startup time, regardless of version, is to
not use `PropertiesLauncher`.

Here is basic startup time before and after with the 2.17.2 version of
Zipkin:

Before (using PropertiesLauncher)
```bash
Started ZipkinServer in 3.641 seconds (JVM running for 5.009)
```

After (running the main class)
```bash
Started ZipkinServer in 3.267 seconds (JVM running for 4.31)
```

Note: even before this change we extracted Zipkin's jar first, so the
entire gains here are only from not using `PropertiesLauncher`.